### PR TITLE
Fix condition for checking whether priority is set or not

### DIFF
--- a/src/main/java/com/semmle/jira/addon/config/ProcessedConfig.java
+++ b/src/main/java/com/semmle/jira/addon/config/ProcessedConfig.java
@@ -67,7 +67,7 @@ public class ProcessedConfig {
     }
 
     priorityLevel = null;
-    if (config.getPriorityLevelId() == null || !config.getPriorityLevelId().isEmpty()) {
+    if (config.getPriorityLevelId() != null && !config.getPriorityLevelId().isEmpty()) {
       priorityLevel =
           ComponentAccessor.getConstantsManager().getPriorityObject(config.getPriorityLevelId());
       if (priorityLevel == null)


### PR DESCRIPTION
We should only set `priorityLevel` set  if the configured priority is not `null` and not `empty` .

@nickfyson @Daverlo 