### PR TITLE
Add scope 'compile' to GSON dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
 			<version>2.8.5</version>
+			<scope>compile</scope>
 		</dependency>
 		<!-- Uncomment to use TestKit in your project. Details at https://bitbucket.org/atlassian/jira-testkit -->
 		<!-- You can read more about TestKit at https://developer.atlassian.com/display/JIRADEV/Plugin+Tutorial+-+Smarter+integration+testing+with+TestKit -->


### PR DESCRIPTION
This causes the GSON library to be included in the addon jar.

See also: https://developer.atlassian.com/server/framework/atlassian-sdk/managing-dependencies/#using-third-party-code