### PR TITLE
Fix the status code to be 500 when no valid transition found

### DIFF
--- a/src/main/java/com/semmle/jira/addon/LgtmServlet.java
+++ b/src/main/java/com/semmle/jira/addon/LgtmServlet.java
@@ -201,7 +201,7 @@ public class LgtmServlet extends HttpServlet {
         return;
       }
     }
-    sendError(resp, HttpServletResponse.SC_NOT_FOUND, "No valid transition found.");
+    sendError(resp, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "No valid transition found.");
   }
 
   private void writeErrors(ServiceResult result, HttpServletResponse resp) throws IOException {

--- a/src/test/java/com/semmle/jira/addon/TestApplyTransition.java
+++ b/src/test/java/com/semmle/jira/addon/TestApplyTransition.java
@@ -127,8 +127,8 @@ public class TestApplyTransition extends TestCreateAndTransitionBase {
 
     servlet.applyTransition(issueId, resp, targetStatus, config);
 
-    verify(resp.getWriter()).write("{\"code\":404,\"error\":\"No valid transition found.\"}");
-    verify(resp).setStatus(404);
+    verify(resp.getWriter()).write("{\"code\":500,\"error\":\"No valid transition found.\"}");
+    verify(resp).setStatus(500);
   }
 
   @Test


### PR DESCRIPTION
Fix the status code to be 500 when no valid transition found (404 only makes sense when the ticket itself was not found).

FYI @aibaars 