### PR TITLE
Add post-functions that update the resolution field

### DIFF
--- a/src/main/java/com/semmle/jira/addon/LgtmServlet.java
+++ b/src/main/java/com/semmle/jira/addon/LgtmServlet.java
@@ -27,7 +27,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -48,8 +47,7 @@ public class LgtmServlet extends HttpServlet {
   }
 
   @Override
-  protected void doPost(HttpServletRequest req, HttpServletResponse resp)
-      throws ServletException, IOException {
+  protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
     resp.setContentType("application/json");
 
     String pathInfo = req.getPathInfo();

--- a/src/main/java/com/semmle/jira/addon/config/init/PluginEnabledHandler.java
+++ b/src/main/java/com/semmle/jira/addon/config/init/PluginEnabledHandler.java
@@ -64,7 +64,13 @@ public class PluginEnabledHandler implements InitializingBean, DisposableBean {
       statusesJson = IOUtils.toString(is, "UTF-8");
     }
 
-    WorkflowUtils.createWorkflow(Constants.WORKFLOW_NAME, workflowXml, statusesJson);
+    String resolutionsJson;
+    try (InputStream is = classLoader.getResourceAsStream("workflow/resolutions.json")) {
+      resolutionsJson = IOUtils.toString(is, "UTF-8");
+    }
+
+    WorkflowUtils.createWorkflow(
+        Constants.WORKFLOW_NAME, workflowXml, statusesJson, resolutionsJson);
 
     String layoutJson;
     try (InputStream is = classLoader.getResourceAsStream("workflow/layout.v2.json")) {

--- a/src/main/java/com/semmle/jira/addon/config/init/WorkflowResolution.java
+++ b/src/main/java/com/semmle/jira/addon/config/init/WorkflowResolution.java
@@ -1,0 +1,13 @@
+package com.semmle.jira.addon.config.init;
+
+public class WorkflowResolution {
+  public final String originalId;
+  public final String name;
+  public final String description;
+
+  public WorkflowResolution(String originalId, String name, String description) {
+    this.originalId = originalId;
+    this.name = name;
+    this.description = description;
+  }
+}

--- a/src/main/java/com/semmle/jira/addon/config/init/WorkflowUtils.java
+++ b/src/main/java/com/semmle/jira/addon/config/init/WorkflowUtils.java
@@ -1,8 +1,17 @@
 package com.semmle.jira.addon.config.init;
 
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.commons.codec.digest.DigestUtils;
+
 import com.atlassian.jira.component.ComponentAccessor;
 import com.atlassian.jira.config.ConstantsManager;
+import com.atlassian.jira.config.ResolutionManager;
 import com.atlassian.jira.config.StatusManager;
+import com.atlassian.jira.issue.resolution.Resolution;
 import com.atlassian.jira.issue.status.Status;
 import com.atlassian.jira.issue.status.category.StatusCategory;
 import com.atlassian.jira.issue.status.category.StatusCategoryImpl;
@@ -15,25 +24,38 @@ import com.atlassian.jira.workflow.WorkflowUtil;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import com.opensymphony.workflow.FactoryException;
+import com.opensymphony.workflow.loader.ActionDescriptor;
+import com.opensymphony.workflow.loader.FunctionDescriptor;
 import com.opensymphony.workflow.loader.StepDescriptor;
 import com.opensymphony.workflow.loader.WorkflowDescriptor;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import org.apache.commons.codec.digest.DigestUtils;
 
 public class WorkflowUtils {
 
-  static void createWorkflow(String workflowName, String workflowXml, String statusesJson)
+  private static final String UPDATE_FIELD_FUNCTION_ID =
+      com.atlassian.jira.workflow.function.issue.UpdateIssueFieldFunction.class.getName();
+
+  static void createWorkflow(
+      String workflowName, String workflowXml, String statusesJson, String resolutionsJson)
       throws FactoryException {
     WorkflowManager workflowManager = ComponentAccessor.getWorkflowManager();
     if (workflowManager.workflowExists(workflowName)) {
       return;
     }
 
+    WorkflowDescriptor descriptor = WorkflowUtil.convertXMLtoWorkflowDescriptor(workflowXml);
+
+    updateStatuses(descriptor, statusesJson);
+    updateResolutions(descriptor, resolutionsJson);
+
+    JiraWorkflow workflow = new ConfigurableJiraWorkflow(workflowName, descriptor, workflowManager);
+    workflowManager.createWorkflow( // User is not needed for creating
+        (ApplicationUser) null, workflow);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static void updateStatuses(WorkflowDescriptor descriptor, String statusesJson) {
     Map<String, WorkflowStatus> statuses = mapStatuses(statusesJson);
 
-    WorkflowDescriptor descriptor = WorkflowUtil.convertXMLtoWorkflowDescriptor(workflowXml);
     List<StepDescriptor> steps = descriptor.getSteps();
     for (StepDescriptor step : steps) {
       Map<String, String> meta = step.getMetaAttributes();
@@ -54,10 +76,51 @@ public class WorkflowUtils {
       }
       meta.put("jira.status.id", status.getId());
     }
+  }
 
-    JiraWorkflow workflow = new ConfigurableJiraWorkflow(workflowName, descriptor, workflowManager);
-    workflowManager.createWorkflow( // User is not needed for creating
-        (ApplicationUser) null, workflow);
+  @SuppressWarnings("unchecked")
+  private static void updateResolutions(WorkflowDescriptor descriptor, String resolutionsJson) {
+    WorkflowResolution[] resolutions =
+        new Gson().fromJson(resolutionsJson, WorkflowResolution[].class);
+
+    ResolutionManager resolutionManager = ComponentAccessor.getComponent(ResolutionManager.class);
+    Map<String, String> existing =
+        resolutionManager.getResolutions().stream()
+            .collect(Collectors.toMap(Resolution::getName, Resolution::getId));
+
+    // Insert some aliases to try if the preferred resolutions don't exist
+    existing.computeIfAbsent("Done", x -> existing.get("Fixed"));
+    existing.computeIfAbsent("Won't Do", x -> existing.get("Won't Fix"));
+
+    Map<String, String> resolutionsMap = new LinkedHashMap<>();
+    for (WorkflowResolution resolution : resolutions) {
+      String newId = existing.get(resolution.name);
+      if (newId == null) {
+        newId = resolutionManager.createResolution(resolution.name, resolution.description).getId();
+      }
+      resolutionsMap.put(resolution.originalId, newId);
+    }
+    List<StepDescriptor> steps = descriptor.getSteps();
+    for (StepDescriptor step : steps) {
+
+      for (ActionDescriptor action : (List<ActionDescriptor>) step.getActions()) {
+        for (FunctionDescriptor function :
+            (List<FunctionDescriptor>) action.getUnconditionalResult().getPostFunctions()) {
+          // skip non-class functions
+          if (!"class".equals(function.getType())) continue;
+
+          Map<String, String> args = function.getArgs();
+          Object name = args.get("class.name");
+          if (UPDATE_FIELD_FUNCTION_ID.equals(name)) {
+            if ("resolution".equals(args.get("field.name"))) {
+              String oldValue = (String) args.get("field.value");
+              String newValue = resolutionsMap.get(oldValue);
+              if (newValue != null) args.put("field.value", newValue);
+            }
+          }
+        }
+      }
+    }
   }
 
   static void addLayoutToWorkflow(String workflowName, String layoutJson) {

--- a/src/main/resources/workflow/resolutions.json
+++ b/src/main/resources/workflow/resolutions.json
@@ -1,0 +1,12 @@
+[
+  {
+    "originalId": "10000",
+    "name": "Done",
+    "description": "Work has been completed on this issue."
+  },
+  {
+    "originalId": "10001",
+    "name": "Won't Do",
+    "description": "This issue won't be actioned."
+  }
+]

--- a/src/main/resources/workflow/workflow.xml
+++ b/src/main/resources/workflow/workflow.xml
@@ -3,7 +3,7 @@
 <workflow>
   <meta name="jira.description"></meta>
   <meta name="jira.update.author.key">admin</meta>
-  <meta name="jira.updated.date">1551884607461</meta>
+  <meta name="jira.updated.date">1551963549747</meta>
   <initial-actions>
     <action id="1" name="Create">
       <validators>
@@ -45,6 +45,12 @@
         <unconditional-result old-status="null" status="null" step="2">
           <post-functions>
             <function type="class">
+              <arg name="field.name">resolution</arg>
+              <arg name="full.module.key">com.atlassian.jira.plugin.system.workflowupdate-issue-field-function</arg>
+              <arg name="field.value">10000</arg>
+              <arg name="class.name">com.atlassian.jira.workflow.function.issue.UpdateIssueFieldFunction</arg>
+            </function>
+            <function type="class">
               <arg name="class.name">com.atlassian.jira.workflow.function.issue.UpdateIssueStatusFunction</arg>
             </function>
             <function type="class">
@@ -77,6 +83,12 @@
       <results>
         <unconditional-result old-status="null" status="null" step="1">
           <post-functions>
+            <function type="class">
+              <arg name="field.name">resolution</arg>
+              <arg name="full.module.key">com.atlassian.jira.plugin.system.workflowupdate-issue-field-function</arg>
+              <arg name="field.value"></arg>
+              <arg name="class.name">com.atlassian.jira.workflow.function.issue.UpdateIssueFieldFunction</arg>
+            </function>
             <function type="class">
               <arg name="class.name">com.atlassian.jira.workflow.function.issue.UpdateIssueStatusFunction</arg>
             </function>
@@ -111,6 +123,12 @@
         <unconditional-result old-status="null" status="null" step="3">
           <post-functions>
             <function type="class">
+              <arg name="field.name">resolution</arg>
+              <arg name="full.module.key">com.atlassian.jira.plugin.system.workflowupdate-issue-field-function</arg>
+              <arg name="field.value">10001</arg>
+              <arg name="class.name">com.atlassian.jira.workflow.function.issue.UpdateIssueFieldFunction</arg>
+            </function>
+            <function type="class">
               <arg name="class.name">com.atlassian.jira.workflow.function.issue.UpdateIssueStatusFunction</arg>
             </function>
             <function type="class">
@@ -141,6 +159,12 @@
           <results>
             <unconditional-result old-status="null" status="null" step="3">
               <post-functions>
+                <function type="class">
+                  <arg name="field.name">resolution</arg>
+                  <arg name="full.module.key">com.atlassian.jira.plugin.system.workflowupdate-issue-field-function</arg>
+                  <arg name="field.value">10001</arg>
+                  <arg name="class.name">com.atlassian.jira.workflow.function.issue.UpdateIssueFieldFunction</arg>
+                </function>
                 <function type="class">
                   <arg name="full.module.key">com.semmle.lgtm-jira-addonlgtm-dismiss-alert</arg>
                   <arg name="class.name">com.semmle.jira.addon.workflow.LgtmDismissAlert</arg>
@@ -180,6 +204,12 @@
           <results>
             <unconditional-result old-status="null" status="null" step="1">
               <post-functions>
+                <function type="class">
+                  <arg name="field.name">resolution</arg>
+                  <arg name="full.module.key">com.atlassian.jira.plugin.system.workflowupdate-issue-field-function</arg>
+                  <arg name="field.value"></arg>
+                  <arg name="class.name">com.atlassian.jira.workflow.function.issue.UpdateIssueFieldFunction</arg>
+                </function>
                 <function type="class">
                   <arg name="full.module.key">com.semmle.lgtm-jira-addonlgtm-dismiss-alert</arg>
                   <arg name="class.name">com.semmle.jira.addon.workflow.LgtmDismissAlert</arg>
@@ -242,6 +272,12 @@
           <results>
             <unconditional-result old-status="null" status="null" step="1">
               <post-functions>
+                <function type="class">
+                  <arg name="field.name">resolution</arg>
+                  <arg name="full.module.key">com.atlassian.jira.plugin.system.workflowupdate-issue-field-function</arg>
+                  <arg name="field.value"></arg>
+                  <arg name="class.name">com.atlassian.jira.workflow.function.issue.UpdateIssueFieldFunction</arg>
+                </function>
                 <function type="class">
                   <arg name="full.module.key">com.semmle.lgtm-jira-addonlgtm-dismiss-alert</arg>
                   <arg name="class.name">com.semmle.jira.addon.workflow.LgtmDismissAlert</arg>


### PR DESCRIPTION
This pull request:
* adds support for automatically mapping and creating Resolutions.
* adds update resolution field post-functions to the transitions of
the workflow.