### PR TITLE
Improve usability of the add-on config page

### DIFF
--- a/src/main/resources/admin.vm
+++ b/src/main/resources/admin.vm
@@ -5,13 +5,32 @@
     <meta name="admin.active.section" content="admin_plugins_menu"/>
   </head>
   <body>
-  	<h1>LGTM Add-on Configuration</h1>
-  	<h3>Webhook Endpoint</h3>
-  	<p>The webhook URL for entry into issue tracker configuration in LGTM Enterprise.</p>
-  	<p id="webhookUrl"></p>
-  	<h3>Settings</h3>
-	<div id="message-context"></div>
-    <form id="admin" class="aui">
+    <h1>LGTM add-on configuration</h1>
+    <form id="admin" class="aui" style="width:2000px;">
+    
+      <h3>Jira settings</h3>
+      <div class="field-group">
+        <label for="user">$i18n.getText("lgtm-servlet.admin.user.label")</label>
+        <input type="text" id="user" name="user" class="text">
+      </div>
+      <div class="field-group">
+        <label for="project">$i18n.getText("lgtm-servlet.admin.project.label")</label>
+        <select id="project">
+          <option value="none"></option>
+        </select>
+      </div>
+      <div class="field-group">
+        <label for="priority">$i18n.getText("lgtm-servlet.admin.priority.label")</label>
+        <select id="priority">
+        	<option value="none"></option>
+        </select>
+      </div>
+      <div class="field-group">
+        <label for="user">$i18n.getText("lgtm-servlet.admin.incomingHookUrl.label")</label>
+        <input readonly type="text" id="incomingHookUrl" name="incomingHookUrl" class="text readonly">
+      </div>
+      
+      <h3>LGTM settings</h3>
       <div class="field-group">
         <label for="secret">$i18n.getText("lgtm-servlet.admin.secret.label")</label>
         <input type="text" id="secret" name="secret" class="text">
@@ -21,24 +40,9 @@
         <input type="text" id="externalHookUrl" name="externalHookUrl" class="text">
       </div>
       <div class="field-group">
-        <label for="user">$i18n.getText("lgtm-servlet.admin.user.label")</label>
-        <input type="text" id="user" name="user" class="text">
-      </div>
-      <div class="field-group">
-        <label for="project">$i18n.getText("lgtm-servlet.admin.project.label")</label>
-        <select id="project">
-        	<option value="none"></option>
-	    </select>
-      </div>
-      <div class="field-group">
-        <label for="priority">$i18n.getText("lgtm-servlet.admin.priority.label")</label>
-        <select id="priority">
-        	<option value="none"></option>
-	    </select>
-      </div>
-      <div class="field-group">
         <input type="submit" value="$i18n.getText("lgtm-servlet.admin.save.label")" class="button">
       </div>
     </form>
+    <div id="message-context"></div>
   </body>
 </html>

--- a/src/main/resources/admin.vm
+++ b/src/main/resources/admin.vm
@@ -6,7 +6,7 @@
   </head>
   <body>
     <h1>LGTM add-on configuration</h1>
-    <form id="admin" class="aui" style="width:2000px;">
+    <form id="admin" class="aui">
     
       <h3>Jira settings</h3>
       <div class="field-group">

--- a/src/main/resources/css/lgtm-addon.css
+++ b/src/main/resources/css/lgtm-addon.css
@@ -1,0 +1,7 @@
+form.aui .text, form.aui .aui-select2-container  {
+    max-width: 450px;
+}
+
+form.aui input[readonly]  {
+    background:#E6E6E6;
+}

--- a/src/main/resources/js/lgtm-addon.js
+++ b/src/main/resources/js/lgtm-addon.js
@@ -8,7 +8,7 @@ var externalHookUrlFieldId = "#externalHookUrl";
 var projectFieldId = "#project";
 var priorityFieldId = "#priority";
 
-var webhookUrlFieldId = "#webhookUrl";
+var webhookUrlFieldId = "#incomingHookUrl";
 var urlCodeId = "urlCode";
 var key = "webhook";
 
@@ -43,11 +43,7 @@ var key = "webhook";
 })();
 
 function renderWebhookUrl(url) {
-	AJS.$("#"+urlCodeId).remove();
-	var urlCode = document.createElement('code');
-	urlCode.id = urlCodeId;
-	urlCode.textContent = url;
-	AJS.$(webhookUrlFieldId).append(urlCode);
+	AJS.$(webhookUrlFieldId).val(url);
 }
 
 function loadProjects() {

--- a/src/main/resources/lgtm-addon.properties
+++ b/src/main/resources/lgtm-addon.properties
@@ -4,11 +4,12 @@ lgtm-servlet.description=The LGTM Add-on
 
 lgtm-servlet.admin.label=LGTM Add-on Admin
 
-lgtm-servlet.admin.project.label=Project:
+lgtm-servlet.admin.project.label=Jira project:
 lgtm-servlet.admin.key.label=Key:
-lgtm-servlet.admin.secret.label=Secret:
-lgtm-servlet.admin.externalHookUrl.label=LGTM status update URL
-lgtm-servlet.admin.user.label=Username:
+lgtm-servlet.admin.secret.label=Shared secret:
+lgtm-servlet.admin.externalHookUrl.label=LGTM endpoint:
+lgtm-servlet.admin.incomingHookUrl.label=Tracker endpoint:
+lgtm-servlet.admin.user.label=Jira username:
 lgtm-servlet.admin.issueType.label=Issue type:
 lgtm-servlet.admin.closedStatus.label=Closed status:
 lgtm-servlet.admin.reopenedStatus.label=Reopened status:


### PR DESCRIPTION
This PR changes the add-on config page, making it clearer for users which pieces of information come from where. We adopt the terminology `Tracker endpoint` and `LGTM endpoint` and use the same on LGTM itself, meaning that fields which should contain the same value are identically named.

![image](https://user-images.githubusercontent.com/1482231/54041720-5493a800-41c0-11e9-9b60-c5e3f9af71d0.png)

FYI @aibaars @Daverlo @Semmle/doc 