### PR TITLE
 Remove hardcoded name of 'confirmed false positive' status

### DIFF
--- a/src/main/java/com/semmle/jira/addon/util/Constants.java
+++ b/src/main/java/com/semmle/jira/addon/util/Constants.java
@@ -4,13 +4,7 @@ public class Constants {
   public static final String WORKFLOW_NAME = "LGTM alert";
   public static final String ISSUE_TYPE_NAME = "LGTM alert";
 
-  public static final String WORKFLOW_OPEN_STATUS_NAME = "Open";
-  public static final String WORKFLOW_CLOSED_STATUS_NAME = "Closed";
-  public static final String WORKFLOW_SUPPRESSED_STATUS_NAME = "Suppressed";
-  public static final String WORKFLOW_FALSE_POSITIVE_STATUS_NAME = "False Positive";
-
   public static final String WORKFLOW_REOPEN_TRANSITION_NAME = "LGTM.Reopen";
   public static final String WORKFLOW_CLOSE_TRANSITION_NAME = "LGTM.Close";
-
   public static final String WORKFLOW_SUPPRESS_TRANSITION_NAME = "LGTM.Suppress";
 }

--- a/src/test/java/com/semmle/jira/addon/TestApplyTransition.java
+++ b/src/test/java/com/semmle/jira/addon/TestApplyTransition.java
@@ -67,7 +67,7 @@ public class TestApplyTransition extends TestCreateAndTransitionBase {
     MutableIssue issue = mock(MutableIssue.class);
 
     servlet.applyTransition(
-        issue, Constants.WORKFLOW_CLOSE_TRANSITION_NAME, config.getUser(), resp);
+        issue, Constants.WORKFLOW_CLOSE_TRANSITION_NAME, true, config.getUser(), resp);
 
     verify(resp.getWriter()).write("{\"code\":500,\"error\":\"No valid transition found.\"}");
     verify(resp).setStatus(500);
@@ -88,7 +88,7 @@ public class TestApplyTransition extends TestCreateAndTransitionBase {
     when(issue.getStatus()).thenReturn(new MockStatus("100", "StatusName"));
 
     servlet.applyTransition(
-        issue, Constants.WORKFLOW_CLOSE_TRANSITION_NAME, config.getUser(), resp);
+        issue, Constants.WORKFLOW_CLOSE_TRANSITION_NAME, true, config.getUser(), resp);
     // There was an applicable transition, however, it could not be executed. We just log a message
     // if this happens.
     Assert.assertEquals(
@@ -111,7 +111,7 @@ public class TestApplyTransition extends TestCreateAndTransitionBase {
     when(issueResult.getIssue()).thenReturn(issue);
 
     servlet.applyTransition(
-        issue, Constants.WORKFLOW_CLOSE_TRANSITION_NAME, config.getUser(), resp);
+        issue, Constants.WORKFLOW_CLOSE_TRANSITION_NAME, true, config.getUser(), resp);
 
     verify(resp).setStatus(200);
   }

--- a/src/test/java/com/semmle/jira/addon/TestApplyTransition.java
+++ b/src/test/java/com/semmle/jira/addon/TestApplyTransition.java
@@ -1,7 +1,7 @@
 package com.semmle.jira.addon;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyInt;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -64,7 +64,8 @@ public class TestApplyTransition extends TestCreateAndTransitionBase {
 
     MutableIssue issue = mock(MutableIssue.class);
 
-    servlet.applyTransition(issue, Constants.WORKFLOW_CLOSE_TRANSITION_NAME, resp, config);
+    servlet.applyTransition(
+        issue, Constants.WORKFLOW_CLOSE_TRANSITION_NAME, config.getUser(), resp);
 
     verify(resp.getWriter()).write("{\"code\":500,\"error\":\"No valid transition found.\"}");
     verify(resp).setStatus(500);
@@ -83,7 +84,8 @@ public class TestApplyTransition extends TestCreateAndTransitionBase {
 
     MutableIssue issue = mock(MutableIssue.class);
 
-    servlet.applyTransition(issue, Constants.WORKFLOW_CLOSE_TRANSITION_NAME, resp, config);
+    servlet.applyTransition(
+        issue, Constants.WORKFLOW_CLOSE_TRANSITION_NAME, config.getUser(), resp);
 
     verify(resp).setStatus(500);
   }
@@ -101,7 +103,8 @@ public class TestApplyTransition extends TestCreateAndTransitionBase {
     MutableIssue issue = mock(MutableIssue.class);
     when(issueResult.getIssue()).thenReturn(issue);
 
-    servlet.applyTransition(issue, Constants.WORKFLOW_CLOSE_TRANSITION_NAME, resp, config);
+    servlet.applyTransition(
+        issue, Constants.WORKFLOW_CLOSE_TRANSITION_NAME, config.getUser(), resp);
 
     verify(resp).setStatus(200);
   }

--- a/src/test/java/com/semmle/jira/addon/TestLgtmServletBase.java
+++ b/src/test/java/com/semmle/jira/addon/TestLgtmServletBase.java
@@ -8,6 +8,8 @@ import com.atlassian.sal.api.pluginsettings.PluginSettingsFactory;
 import com.atlassian.sal.api.transaction.TransactionTemplate;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.List;
 import javax.servlet.http.HttpServletResponse;
 import org.junit.Before;
 import org.junit.Rule;
@@ -19,12 +21,21 @@ public class TestLgtmServletBase {
   PluginSettingsFactory pluginSettingsFactory;
   TransactionTemplate transactionTemplate;
   LgtmServlet servlet;
+  List<String> log = new ArrayList<>();
 
   @Before
   public void setupServlet() {
     pluginSettingsFactory = mock(PluginSettingsFactory.class);
     transactionTemplate = mock(TransactionTemplate.class);
-    servlet = new LgtmServlet(pluginSettingsFactory, transactionTemplate);
+    servlet =
+        new LgtmServlet(pluginSettingsFactory, transactionTemplate) {
+          private static final long serialVersionUID = 1L;
+
+          @Override
+          public void log(String msg) {
+            log.add(msg);
+          }
+        };
   }
 
   public HttpServletResponse mockResponse() throws IOException {


### PR DESCRIPTION

* Remove hardcoded name of 'confirmed false positive' status
* Allow transition to be aborted by Validator function
* Add Validator to avoid running the LGTM.Suppress transition if the issue is already in a suppressed state