### PR TITLE
Remove Gson dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,12 +109,6 @@
 			<version>1.1.1</version>
 			<scope>provided</scope>
 		</dependency>
-		<dependency>
-			<groupId>com.google.code.gson</groupId>
-			<artifactId>gson</artifactId>
-			<version>2.8.5</version>
-			<scope>compile</scope>
-		</dependency>
 		<!-- Uncomment to use TestKit in your project. Details at https://bitbucket.org/atlassian/jira-testkit -->
 		<!-- You can read more about TestKit at https://developer.atlassian.com/display/JIRADEV/Plugin+Tutorial+-+Smarter+integration+testing+with+TestKit -->
 		<dependency>
@@ -190,7 +184,11 @@
 						<Export-Package>com.semmle.jira.addon.api,</Export-Package>
 						<!-- Add package import here -->
 						<Import-Package>org.springframework.osgi.*;resolution:="optional",
-							org.eclipse.gemini.blueprint.*;resolution:="optional", *</Import-Package>
+							org.eclipse.gemini.blueprint.*;resolution:="optional",
+							org.codehaus.jackson.*,
+							org.codehaus.jackson.annotate.*,
+							org.codehaus.jackson.map.*,
+							 *</Import-Package>
 						<!-- Ensure plugin is spring powered -->
 						<Spring-Context>*</Spring-Context>
 					</instructions>

--- a/src/main/java/com/semmle/jira/addon/JsonError.java
+++ b/src/main/java/com/semmle/jira/addon/JsonError.java
@@ -1,10 +1,16 @@
 package com.semmle.jira.addon;
 
-public class JsonError {
-  public int code;
-  public String error;
+import org.codehaus.jackson.annotate.JsonCreator;
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import org.codehaus.jackson.annotate.JsonProperty;
 
-  public JsonError(int code, String error) {
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class JsonError {
+  @JsonProperty public int code;
+  @JsonProperty public String error;
+
+  @JsonCreator
+  public JsonError(@JsonProperty("code") int code, @JsonProperty("error") String error) {
     this.code = code;
     this.error = error;
   }

--- a/src/main/java/com/semmle/jira/addon/LgtmServlet.java
+++ b/src/main/java/com/semmle/jira/addon/LgtmServlet.java
@@ -12,8 +12,6 @@ import com.atlassian.jira.workflow.TransitionOptions.Builder;
 import com.atlassian.plugin.spring.scanner.annotation.imports.ComponentImport;
 import com.atlassian.sal.api.pluginsettings.PluginSettingsFactory;
 import com.atlassian.sal.api.transaction.TransactionTemplate;
-import com.google.gson.Gson;
-import com.google.gson.JsonSyntaxException;
 import com.opensymphony.workflow.loader.ActionDescriptor;
 import com.semmle.jira.addon.Request.Transition;
 import com.semmle.jira.addon.config.Config;
@@ -22,7 +20,6 @@ import com.semmle.jira.addon.config.ProcessedConfig;
 import com.semmle.jira.addon.util.Constants;
 import com.semmle.jira.addon.util.JiraUtils;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
@@ -63,8 +60,8 @@ public class LgtmServlet extends HttpServlet {
 
     Request request;
     try {
-      request = new Gson().fromJson(new String(bytes, StandardCharsets.UTF_8), Request.class);
-    } catch (JsonSyntaxException e) {
+      request = Util.JSON.readValue(bytes, Request.class);
+    } catch (IOException e) {
       String message = e.getCause() != null ? " - " + e.getCause().getMessage() : "";
       sendError(
           resp, HttpServletResponse.SC_BAD_REQUEST, "Syntax error in request body: " + message);
@@ -240,6 +237,6 @@ public class LgtmServlet extends HttpServlet {
     resp.setContentType("application/json");
     resp.setCharacterEncoding("UTF-8");
     resp.setStatus(code);
-    resp.getWriter().write(new Gson().toJson(value));
+    Util.JSON.writeValue(resp.getOutputStream(), value);
   }
 }

--- a/src/main/java/com/semmle/jira/addon/Request.java
+++ b/src/main/java/com/semmle/jira/addon/Request.java
@@ -1,22 +1,31 @@
 package com.semmle.jira.addon;
 
-import com.google.gson.annotations.SerializedName;
+import org.codehaus.jackson.annotate.JsonCreator;
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import org.codehaus.jackson.annotate.JsonProperty;
+import org.codehaus.jackson.annotate.JsonValue;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Request {
 
-  public final Transition transition;
+  @JsonProperty public final Transition transition;
 
-  @SerializedName("issue-id")
+  @JsonProperty("issue-id")
   public final Long issueId;
 
-  public final Project project;
-  public final Alert alert;
+  @JsonProperty public final Project project;
+  @JsonProperty public final Alert alert;
 
   public Request(Transition transition, Long issueId) {
     this(transition, issueId, null, null);
   }
 
-  public Request(Transition transition, Long issueId, Project project, Alert alert) {
+  @JsonCreator
+  public Request(
+      @JsonProperty("transition") Transition transition,
+      @JsonProperty("issue-id") Long issueId,
+      @JsonProperty("project") Project project,
+      @JsonProperty("alert") Alert alert) {
     this.transition = transition;
     this.issueId = issueId;
     this.project = project;
@@ -69,16 +78,11 @@ public class Request {
     return String.format("%s (%s)", this.alert.query.name, this.project.name);
   }
 
-  public enum Transition {
-    @SerializedName("create")
+  public static enum Transition {
     CREATE("create"),
-    @SerializedName("reopen")
     REOPEN("reopen"),
-    @SerializedName("close")
     CLOSE("close"),
-    @SerializedName("suppress")
     SUPPRESS("suppress"),
-    @SerializedName("unsuppress")
     UNSUPPRESS("unsuppress");
 
     public final String value;
@@ -87,21 +91,36 @@ public class Request {
       this.value = value;
     }
 
+    @JsonCreator
+    public static Transition fromString(String value) {
+      for (Transition transition : Transition.values()) {
+        if (transition.value.equals(value)) return transition;
+      }
+      throw new IllegalArgumentException("Invalid transition:" + value);
+    }
+
+    @JsonValue
     public String toString() {
       return value;
     }
   }
 
+  @JsonIgnoreProperties(ignoreUnknown = true)
   public static class Project {
-    public final Long id;
+    @JsonProperty public final Long id;
 
-    @SerializedName("url-identifier")
+    @JsonProperty("url-identifier")
     public final String urlIdentifier;
 
-    public final String name;
-    public final String url;
+    @JsonProperty public final String name;
+    @JsonProperty public final String url;
 
-    public Project(Long id, String urlIdentifier, String name, String url) {
+    @JsonCreator
+    public Project(
+        @JsonProperty("id") Long id,
+        @JsonProperty("url-identifier") String urlIdentifier,
+        @JsonProperty("name") String name,
+        @JsonProperty("url") String url) {
       this.id = id;
       this.urlIdentifier = urlIdentifier;
       this.name = name;
@@ -117,13 +136,19 @@ public class Request {
     }
   }
 
+  @JsonIgnoreProperties(ignoreUnknown = true)
   public static class Alert {
-    public final String file;
-    public final String message;
-    public final String url;
-    public final Query query;
+    @JsonProperty public final String file;
+    @JsonProperty public final String message;
+    @JsonProperty public final String url;
+    @JsonProperty public final Query query;
 
-    public Alert(String file, String message, String url, Query query) {
+    @JsonCreator
+    public Alert(
+        @JsonProperty("file") String file,
+        @JsonProperty("message") String message,
+        @JsonProperty("url") String url,
+        @JsonProperty("query") Query query) {
       this.file = file;
       this.message = message;
       this.url = url;
@@ -138,11 +163,13 @@ public class Request {
       return true;
     }
 
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Query {
-      public final String name;
-      public final String url;
+      @JsonProperty public final String name;
+      @JsonProperty public final String url;
 
-      public Query(String name, String url) {
+      @JsonCreator
+      public Query(@JsonProperty("name") String name, @JsonProperty("url") String url) {
         this.name = name;
         this.url = url;
       }

--- a/src/main/java/com/semmle/jira/addon/Response.java
+++ b/src/main/java/com/semmle/jira/addon/Response.java
@@ -1,12 +1,16 @@
 package com.semmle.jira.addon;
 
-import com.google.gson.annotations.SerializedName;
+import org.codehaus.jackson.annotate.JsonCreator;
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import org.codehaus.jackson.annotate.JsonProperty;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Response {
-  @SerializedName("issue-id")
+  @JsonProperty("issue-id")
   public final String issueId;
 
-  public Response(Long issueId) {
+  @JsonCreator
+  public Response(@JsonProperty("issue-id") Long issueId) {
     this.issueId = issueId.toString();
   }
 }

--- a/src/main/java/com/semmle/jira/addon/Util.java
+++ b/src/main/java/com/semmle/jira/addon/Util.java
@@ -7,8 +7,21 @@ import java.util.Arrays;
 import java.util.List;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
+import org.codehaus.jackson.JsonGenerator;
+import org.codehaus.jackson.JsonParser;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
 
 public class Util {
+
+  public static final ObjectMapper JSON = new ObjectMapper();
+
+  static {
+    JSON.configure(JsonParser.Feature.AUTO_CLOSE_SOURCE, false);
+    JSON.configure(JsonGenerator.Feature.AUTO_CLOSE_TARGET, false);
+    JSON.setSerializationInclusion(Inclusion.NON_NULL);
+  }
+
   public static boolean signatureIsValid(
       String lgtmSecret, byte[] requestBytes, String lgtmSignature) {
     String hmac = calculateHmac(lgtmSecret, requestBytes);

--- a/src/main/java/com/semmle/jira/addon/config/init/PluginEnabledHandler.java
+++ b/src/main/java/com/semmle/jira/addon/config/init/PluginEnabledHandler.java
@@ -9,15 +9,14 @@ import com.atlassian.plugin.spring.scanner.annotation.component.Scanned;
 import com.atlassian.plugin.spring.scanner.annotation.export.ExportAsService;
 import com.atlassian.plugin.spring.scanner.annotation.imports.ComponentImport;
 import com.opensymphony.workflow.FactoryException;
+import com.semmle.jira.addon.Util;
 import com.semmle.jira.addon.util.Constants;
 import com.semmle.jira.addon.util.JiraUtils;
 import com.semmle.jira.addon.util.WorkflowNotFoundException;
-
 import java.io.IOException;
 import java.io.InputStream;
 import javax.inject.Inject;
 import javax.inject.Named;
-
 import org.apache.commons.io.IOUtils;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
@@ -57,7 +56,6 @@ public class PluginEnabledHandler implements InitializingBean, DisposableBean {
       } catch (WorkflowNotFoundException e1) {
         createLgtmWorkflow();
       }
-      
     }
   }
 
@@ -68,18 +66,17 @@ public class PluginEnabledHandler implements InitializingBean, DisposableBean {
       workflowXml = IOUtils.toString(is, "UTF-8");
     }
 
-    String statusesJson;
+    WorkflowStatus[] statuses;
     try (InputStream is = classLoader.getResourceAsStream("workflow/statuses.json")) {
-      statusesJson = IOUtils.toString(is, "UTF-8");
+      statuses = Util.JSON.readValue(is, WorkflowStatus[].class);
     }
 
-    String resolutionsJson;
+    WorkflowResolution[] resolutions;
     try (InputStream is = classLoader.getResourceAsStream("workflow/resolutions.json")) {
-      resolutionsJson = IOUtils.toString(is, "UTF-8");
+      resolutions = Util.JSON.readValue(is, WorkflowResolution[].class);
     }
 
-    WorkflowUtils.createWorkflow(
-        Constants.WORKFLOW_NAME, workflowXml, statusesJson, resolutionsJson);
+    WorkflowUtils.createWorkflow(Constants.WORKFLOW_NAME, workflowXml, statuses, resolutions);
 
     String layoutJson;
     try (InputStream is = classLoader.getResourceAsStream("workflow/layout.v2.json")) {

--- a/src/main/java/com/semmle/jira/addon/config/init/WorkflowResolution.java
+++ b/src/main/java/com/semmle/jira/addon/config/init/WorkflowResolution.java
@@ -1,11 +1,18 @@
 package com.semmle.jira.addon.config.init;
 
-public class WorkflowResolution {
-  public final String originalId;
-  public final String name;
-  public final String description;
+import org.codehaus.jackson.annotate.JsonCreator;
+import org.codehaus.jackson.annotate.JsonProperty;
 
-  public WorkflowResolution(String originalId, String name, String description) {
+public class WorkflowResolution {
+  @JsonProperty public final String originalId;
+  @JsonProperty public final String name;
+  @JsonProperty public final String description;
+
+  @JsonCreator
+  public WorkflowResolution(
+      @JsonProperty("originalId") String originalId,
+      @JsonProperty("name") String name,
+      @JsonProperty("description") String description) {
     this.originalId = originalId;
     this.name = name;
     this.description = description;

--- a/src/main/java/com/semmle/jira/addon/config/init/WorkflowStatus.java
+++ b/src/main/java/com/semmle/jira/addon/config/init/WorkflowStatus.java
@@ -1,13 +1,20 @@
 package com.semmle.jira.addon.config.init;
 
-public class WorkflowStatus {
-  public final String originalId;
-  public final String name;
-  public final String description;
-  public final String statusCategoryId;
+import org.codehaus.jackson.annotate.JsonCreator;
+import org.codehaus.jackson.annotate.JsonProperty;
 
+public class WorkflowStatus {
+  @JsonProperty public final String originalId;
+  @JsonProperty public final String name;
+  @JsonProperty public final String description;
+  @JsonProperty public final String statusCategoryId;
+
+  @JsonCreator
   public WorkflowStatus(
-      String originalId, String name, String description, String statusCategoryId) {
+      @JsonProperty("originalId") String originalId,
+      @JsonProperty("name") String name,
+      @JsonProperty("description") String description,
+      @JsonProperty("statusCategoryId") String statusCategoryId) {
     this.originalId = originalId;
     this.name = name;
     this.description = description;

--- a/src/main/java/com/semmle/jira/addon/config/init/WorkflowUtils.java
+++ b/src/main/java/com/semmle/jira/addon/config/init/WorkflowUtils.java
@@ -15,7 +15,6 @@ import com.atlassian.jira.workflow.JiraWorkflow;
 import com.atlassian.jira.workflow.WorkflowManager;
 import com.atlassian.jira.workflow.WorkflowUtil;
 import com.google.common.collect.ImmutableMap;
-import com.google.gson.Gson;
 import com.opensymphony.workflow.FactoryException;
 import com.opensymphony.workflow.loader.ActionDescriptor;
 import com.opensymphony.workflow.loader.FunctionDescriptor;
@@ -39,7 +38,10 @@ public class WorkflowUtils {
       ResolutionCondition.class.getName();
 
   static void createWorkflow(
-      String workflowName, String workflowXml, String statusesJson, String resolutionsJson)
+      String workflowName,
+      String workflowXml,
+      WorkflowStatus[] statuses,
+      WorkflowResolution[] resolutions)
       throws FactoryException {
     WorkflowManager workflowManager = ComponentAccessor.getWorkflowManager();
     if (workflowManager.workflowExists(workflowName)) {
@@ -48,8 +50,8 @@ public class WorkflowUtils {
 
     WorkflowDescriptor descriptor = WorkflowUtil.convertXMLtoWorkflowDescriptor(workflowXml);
 
-    updateStatuses(descriptor, statusesJson);
-    updateResolutions(descriptor, resolutionsJson);
+    updateStatuses(descriptor, statuses);
+    updateResolutions(descriptor, resolutions);
 
     JiraWorkflow workflow = new ConfigurableJiraWorkflow(workflowName, descriptor, workflowManager);
     workflowManager.createWorkflow( // User is not needed for creating
@@ -57,7 +59,7 @@ public class WorkflowUtils {
   }
 
   @SuppressWarnings("unchecked")
-  private static void updateStatuses(WorkflowDescriptor descriptor, String statusesJson) {
+  private static void updateStatuses(WorkflowDescriptor descriptor, WorkflowStatus[] statusesJson) {
     Map<String, WorkflowStatus> statuses = mapStatuses(statusesJson);
 
     List<StepDescriptor> steps = descriptor.getSteps();
@@ -83,9 +85,8 @@ public class WorkflowUtils {
   }
 
   @SuppressWarnings("unchecked")
-  private static void updateResolutions(WorkflowDescriptor descriptor, String resolutionsJson) {
-    WorkflowResolution[] resolutions =
-        new Gson().fromJson(resolutionsJson, WorkflowResolution[].class);
+  private static void updateResolutions(
+      WorkflowDescriptor descriptor, WorkflowResolution[] resolutions) {
 
     ResolutionManager resolutionManager = ComponentAccessor.getComponent(ResolutionManager.class);
     Map<String, String> existing =
@@ -184,8 +185,7 @@ public class WorkflowUtils {
     return statusManager.createStatus(statusName, description, "status.png", category);
   }
 
-  private static Map<String, WorkflowStatus> mapStatuses(String statusesJson) {
-    WorkflowStatus[] statuses = new Gson().fromJson(statusesJson, WorkflowStatus[].class);
+  private static Map<String, WorkflowStatus> mapStatuses(WorkflowStatus[] statuses) {
 
     Map<String, WorkflowStatus> statusesMap = new LinkedHashMap<String, WorkflowStatus>();
     for (WorkflowStatus status : statuses) {

--- a/src/test/java/com/semmle/jira/addon/Json.java
+++ b/src/test/java/com/semmle/jira/addon/Json.java
@@ -1,0 +1,68 @@
+package com.semmle.jira.addon;
+
+import com.semmle.jira.addon.config.init.WorkflowResolution;
+import com.semmle.jira.addon.config.init.WorkflowStatus;
+import java.io.IOException;
+import org.codehaus.jackson.JsonNode;
+import org.codehaus.jackson.node.ObjectNode;
+import org.codehaus.jackson.node.TextNode;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class Json {
+
+  @Test
+  public void test() throws IOException {
+
+    // Simple transition request
+    String text = "{\"transition\":\"close\",\"issue-id\":1}";
+    testJsonRoundTrip(text, Request.class, true);
+
+    // Detailed create request
+    text =
+        "{\"transition\":\"create\",\"issue-id\":1,\"project\":{\"id\":2,"
+            + "\"url-identifier\":\"g/commons/io\",\"name\":\"CommonsIO\","
+            + "\"url\":\"URL\"},\"alert\":{\"file\":\"file\",\"message\":"
+            + "\"name\",\"url\":\"alert-url\",\"query\":{\"name\":\"name\""
+            + ",\"url\":\"query-url\"}}}";
+
+    testJsonRoundTrip(text, Request.class, true);
+
+    // Response JSON
+    text = "{\"issue-id\":\"1\"}";
+    testJsonRoundTrip(text, Response.class, true);
+
+    // JSON error message
+    text = "{\"code\":500,\"error\":\"hello world\"}";
+    testJsonRoundTrip(text, JsonError.class, true);
+
+    // WorkflowResolution
+    text = "{\"originalId\":\"id\",\"name\":\"name\",\"description\":\"desc\"}";
+    testJsonRoundTrip(text, WorkflowResolution.class, false);
+
+    // WorkflowStatus
+    text =
+        "{\"originalId\":\"id\",\"name\":\"name\",\"description\":\"desc\",\"statusCategoryId\":\"category\"}";
+    testJsonRoundTrip(text, WorkflowStatus.class, false);
+  }
+
+  private static <T> void testJsonRoundTrip(String input, Class<T> cls, boolean unknownFields)
+      throws IOException {
+    T obj = Util.JSON.readValue(input, cls);
+    Assert.assertEquals(input, Util.JSON.writeValueAsString(obj));
+    if (unknownFields) {
+      JsonNode json = Util.JSON.readValue(input, JsonNode.class);
+      insertUnknownField(json);
+      String inputWithCrap = Util.JSON.writeValueAsString(json);
+      obj = Util.JSON.readValue(inputWithCrap, cls);
+      Assert.assertEquals(input, Util.JSON.writeValueAsString(obj));
+    }
+  }
+
+  private static void insertUnknownField(JsonNode json) {
+    if (json instanceof ObjectNode) {
+      ((ObjectNode) json).put("unknownField", new TextNode("some data"));
+      json.forEach(Json::insertUnknownField);
+    }
+  }
+}

--- a/src/test/java/com/semmle/jira/addon/TestApplyTransition.java
+++ b/src/test/java/com/semmle/jira/addon/TestApplyTransition.java
@@ -24,7 +24,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 import javax.servlet.http.HttpServletResponse;
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -69,7 +69,9 @@ public class TestApplyTransition extends TestCreateAndTransitionBase {
     servlet.applyTransition(
         issue, Constants.WORKFLOW_CLOSE_TRANSITION_NAME, true, config.getUser(), resp);
 
-    verify(resp.getWriter()).write("{\"code\":500,\"error\":\"No valid transition found.\"}");
+    Assert.assertEquals(
+        "{\"code\":500,\"error\":\"No valid transition found.\"}",
+        resp.getOutputStream().toString());
     verify(resp).setStatus(500);
   }
 

--- a/src/test/java/com/semmle/jira/addon/TestLgtmServletBase.java
+++ b/src/test/java/com/semmle/jira/addon/TestLgtmServletBase.java
@@ -6,10 +6,12 @@ import static org.mockito.Mockito.when;
 import com.atlassian.jira.junit.rules.MockitoContainer;
 import com.atlassian.sal.api.pluginsettings.PluginSettingsFactory;
 import com.atlassian.sal.api.transaction.TransactionTemplate;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.PrintWriter;
+import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.List;
+import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletResponse;
 import org.junit.Before;
 import org.junit.Rule;
@@ -38,10 +40,29 @@ public class TestLgtmServletBase {
         };
   }
 
+  private static class MockServletOutputStream extends ServletOutputStream {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+    @Override
+    public void write(int b) {
+      out.write(b);
+    }
+
+    @Override
+    public String toString() {
+      try {
+        return out.toString("UTF-8");
+      } catch (UnsupportedEncodingException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
   public HttpServletResponse mockResponse() throws IOException {
     HttpServletResponse resp = mock(HttpServletResponse.class);
-    PrintWriter respWriter = mock(PrintWriter.class);
-    when(resp.getWriter()).thenReturn(respWriter);
+    MockServletOutputStream out = new MockServletOutputStream();
+
+    when(resp.getOutputStream()).thenReturn(out);
 
     return resp;
   }

--- a/src/test/java/com/semmle/jira/addon/TestValidateRequest.java
+++ b/src/test/java/com/semmle/jira/addon/TestValidateRequest.java
@@ -19,6 +19,7 @@ import com.semmle.jira.addon.config.ProcessedConfig;
 import java.io.IOException;
 import java.util.Arrays;
 import javax.servlet.http.HttpServletResponse;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Matchers;
@@ -69,12 +70,12 @@ public class TestValidateRequest extends TestLgtmServletBase {
 
     config.setLgtmSecret(null); // Mocking the configuration is not set
 
-    ProcessedConfig processedConfig =
-        servlet.validateRequest(lgtmSignature, bytes, resp, configKey);
+    servlet.validateRequest(lgtmSignature, bytes, resp, configKey);
 
     verify(resp).setStatus(500);
-    verify(resp.getWriter())
-        .write("{\"code\":500,\"error\":\"Configuration needed – see documentation.\"}");
+    Assert.assertEquals(
+        "{\"code\":500,\"error\":\"Configuration needed – see documentation.\"}",
+        resp.getOutputStream().toString());
   }
 
   @Test
@@ -85,11 +86,11 @@ public class TestValidateRequest extends TestLgtmServletBase {
 
     HttpServletResponse resp = mockResponse();
 
-    ProcessedConfig processedConfig =
-        servlet.validateRequest(lgtmSignature, bytes, resp, configKey);
+    servlet.validateRequest(lgtmSignature, bytes, resp, configKey);
 
     verify(resp).setStatus(403);
-    verify(resp.getWriter()).write("{\"code\":403,\"error\":\"Forbidden.\"}");
+    Assert.assertEquals(
+        "{\"code\":403,\"error\":\"Forbidden.\"}", resp.getOutputStream().toString());
   }
 
   @Test

--- a/src/test/java/it/com/semmle/jira/addon/IntegrationTest.java
+++ b/src/test/java/it/com/semmle/jira/addon/IntegrationTest.java
@@ -12,7 +12,7 @@ import com.atlassian.jira.testkit.client.util.TimeBombLicence;
 import com.atlassian.jira.util.json.JSONException;
 import com.atlassian.jira.util.json.JSONObject;
 import com.google.common.collect.Iterables;
-import com.google.gson.GsonBuilder;
+import com.semmle.jira.addon.Util;
 import com.semmle.jira.addon.config.Config;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -153,7 +153,7 @@ public class IntegrationTest {
         "Basic "
             + Base64.getEncoder().encodeToString(("admin:admin").getBytes(StandardCharsets.UTF_8)));
 
-    httpPut.setEntity(new StringEntity(new GsonBuilder().create().toJson(config)));
+    httpPut.setEntity(new StringEntity(Util.JSON.writeValueAsString(config)));
 
     HttpResponse response = httpClient.execute(httpPut);
 


### PR DESCRIPTION
The Jackson packages are exported by the system bundle. In addition
the [IssueInputParameters](https://docs.atlassian.com/software/jira/docs/api/7.2.1/com/atlassian/jira/issue/IssueInputParameters.html#addProperty-java.lang.String-org.codehaus.jackson.JsonNode-) interface directly depends on jackson's JsonNode. For our
use-cases both Gson and Jackson are fine. Dropping Gson would remove
a dependency.