### PR TITLE
Add detailed error message when manual migration needed

### DIFF
--- a/src/main/java/com/semmle/jira/addon/config/ConfigResource.java
+++ b/src/main/java/com/semmle/jira/addon/config/ConfigResource.java
@@ -78,18 +78,18 @@ public class ConfigResource {
     }
 
     if (!UserUtils.userExists(config.getUsername())) {
-      return Response.status(Status.BAD_REQUEST).header("Error", "username").build();
+      return Response.status(Status.BAD_REQUEST).header("Error", "user-not-found").build();
     }
 
     Project project =
         ComponentAccessor.getProjectManager().getProjectByCurrentKey(config.getProjectKey());
     if (project == null) {
-      return Response.status(Status.BAD_REQUEST).header("Error", "project").build();
+      return Response.status(Status.BAD_REQUEST).header("Error", "project-not-found").build();
     }
     JiraUtils.createLgtmIssueType();
     IssueType lgtmIssueType = JiraUtils.getIssueTypeByName(Constants.ISSUE_TYPE_NAME);
     if (lgtmIssueType == null) {
-      return Response.status(Status.BAD_REQUEST).header("Error", "issueType").build();
+      return Response.status(Status.BAD_REQUEST).header("Error", "issueType-not-found").build();
     }
 
     JiraUtils.addIssueTypeToProject(project, lgtmIssueType);
@@ -100,7 +100,7 @@ public class ConfigResource {
       return Response.status(Status.BAD_REQUEST).header("Error", "workflow-not-found").build();
     } catch (GenericEntityException e) {
       log.error("Error while adding the LGTM workflow to the project", e);
-      return Response.status(Status.BAD_REQUEST).header("Error", "workflow").build();
+      return Response.status(Status.BAD_REQUEST).header("Error", "workflow-generic-error").build();
     } catch (UsedIssueTypeException e) {
       return Response.status(Status.BAD_REQUEST).header("Error", "manual-migration-needed").build();
     }

--- a/src/main/resources/js/lgtm-addon.js
+++ b/src/main/resources/js/lgtm-addon.js
@@ -111,7 +111,7 @@ function updateConfig() {
 
 	if (AJS.$(userFieldId).attr("value") === "") {
 		AJS.messages.error("#message-context", {
-			title : 'Please enter a valid user.',
+			title : 'Please enter a username.',
 			closeable : true,
 			fadeout : true
 		});
@@ -148,7 +148,7 @@ function updateConfig() {
 			fadeout : true
 		});
 	}).fail(function(jqXHR, textStatus, errorThrown) {
-		if (jqXHR.getResponseHeader("Error") === "username") {
+		if (jqXHR.getResponseHeader("Error") === "user-not-found") {
 			AJS.messages.error("#message-context", {
 				title : 'The user ' + AJS.$(userFieldId).attr("value")
 						+ ' does not exist.',
@@ -156,7 +156,7 @@ function updateConfig() {
 				fadeout : true
 			});
 			return;
-		} else if (jqXHR.getResponseHeader("Error") === "project") {
+		} else if (jqXHR.getResponseHeader("Error") === "project-not-found") {
 			// This should not happen
 			AJS.messages.error("#message-context", {
 				title : 'The project "' + AJS.$(projectFieldId).select2('data').text
@@ -165,16 +165,17 @@ function updateConfig() {
 				fadeout : true
 			});
 			return;
-		} else if (jqXHR.getResponseHeader("Error") === "issueType") {
+		} else if (jqXHR.getResponseHeader("Error") === "issueType-not-found") {
 			AJS.messages.error("#message-context", {
 				title : 'The "LGTM alert" issue type could not be found.',
 				closeable : true,
 				fadeout : true
 			});
 			return;
-		} else if (jqXHR.getResponseHeader("Error") === "workflow") {
+		} else if (jqXHR.getResponseHeader("Error") === "workflow-generic-error") {
 			AJS.messages.error("#message-context", {
-				title : 'A problem occurred when adding the LGTM alert workflow to the project.',
+				title : "An error occurred when adding the 'LGTM alert' workflow to the project.",
+				body : 'If this problem persist please contact your Jira administrator.',
 				closeable : true,
 				fadeout : true
 			});
@@ -196,6 +197,7 @@ function updateConfig() {
 		}
 		AJS.messages.error("#message-context", {
 			title : 'An error happened.',
+			body : 'Please try again.',
 			closeable : true,
 			fadeout : true
 		});

--- a/src/main/resources/js/lgtm-addon.js
+++ b/src/main/resources/js/lgtm-addon.js
@@ -196,9 +196,9 @@ function updateConfig() {
 			var body = '<p>There are existing tickets using an old workflow type, and hence a one-time manual migration is needed.</p>' +
 			'<ul>'+
 			'<li>Please go to the <a href="' + AJS.params.baseURL + '/plugins/servlet/project-config/'+
-																				AJS.$('#project').select2('val') +
-																				'/workflows" target="_blank">project workflow page</a> '+
-																	"and select 'Add workflow' followed by 'Add existing'.</li>" +
+				AJS.$('#project').select2('val') +
+				'/workflows" target="_blank">project workflow page</a> '+
+				"and select 'Add workflow' followed by 'Add existing'.</li>" +
 			"<li>On the first screen select 'LGTM workflow' then on the second select 'LGTM alert'. Click 'Finish'.</li>" +
 			"<li>Finally, click 'Publish' and Jira will guide you through mapping tickets to the new workflow.</li>" +
 			'</ul>';
@@ -212,7 +212,7 @@ function updateConfig() {
 			return;
 		}
 		AJS.messages.error("#message-context", {
-			title : 'An error happened.',
+			title : 'An error occurred.',
 			body : 'Please try again.',
 			closeable : true,
 			fadeout : true

--- a/src/main/resources/js/lgtm-addon.js
+++ b/src/main/resources/js/lgtm-addon.js
@@ -182,16 +182,28 @@ function updateConfig() {
 			return;
 		} else if (jqXHR.getResponseHeader("Error") === "workflow-not-found") {
 			AJS.messages.error("#message-context", {
-				title : 'The LGTM alert workflow does not exists. Please install it.',
+				title : 'The LGTM alert workflow does not exists. Please re-enable add-on.',
 				closeable : true,
 				fadeout : true
 			});
 			return;
 		} else if (jqXHR.getResponseHeader("Error") === "manual-migration-needed") {
+			
+			var body = '<p>There are existing tickets using an old workflow type, and hence a one-time manual migration is needed.</p>' +
+			'<ul>'+
+			'<li>Please go to the <a href="' + AJS.params.baseURL + '/plugins/servlet/project-config/'+
+																				AJS.$('#project').select2('val') +
+																				'/workflows" target="_blank">project workflow page</a> '+
+																	"and select 'Add workflow' followed by 'Add existing'.</li>" +
+			"<li>On the first screen select 'LGTM workflow' then on the second select 'LGTM alert'. Click 'Finish'.</li>" +
+			"<li>Finally, click 'Publish' and Jira will guide you through mapping tickets to the new workflow.</li>" +
+			'</ul>';
+			
 			AJS.messages.error("#message-context", {
 				title : 'A manual workflow migration is needed.',
+				body : body,
 				closeable : true,
-				fadeout : true
+				fadeout : false
 			});
 			return;
 		}

--- a/src/main/resources/js/lgtm-addon.js
+++ b/src/main/resources/js/lgtm-addon.js
@@ -95,6 +95,10 @@ function changeSelect2Value(fieldId, newValue) {
 
 function updateConfig() {
 	
+	for (var i = 0; i < AJS.$("#message-context").children().length; i++) {
+		AJS.$("#message-context").children()[i].remove();
+	}
+	
 	if (AJS.$(secretFieldId).attr("value") === "") {
 		AJS.messages.error("#message-context", {
 			title : 'Please enter a valid secret.',


### PR DESCRIPTION
This PR adds an informative error message when a manual migration is needed.

I'd hoped to link directly to the workflow scheme for the chosen project, but there doesn't seem to a way to get that ID from the Rest API. Instead users will need to select the appropriate scheme from a list.

Feedback appreciated on whether it all makes sense!

FYI @aibaars @Daverlo @Semmle/doc 

![image](https://user-images.githubusercontent.com/1482231/54202136-4a76ef80-44c7-11e9-9bfd-fceeb94f4368.png)
