### PR TITLE
Fix status already exists exception

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,12 +53,6 @@
 			<version>${atlassian.spring.scanner.version}</version>
 			<scope>provided</scope>
 		</dependency>
-		<dependency>
-			<groupId>com.atlassian.plugin</groupId>
-			<artifactId>atlassian-spring-scanner-runtime</artifactId>
-			<version>${atlassian.spring.scanner.version}</version>
-			<scope>provided</scope>
-		</dependency>
 		<!-- https://mvnrepository.com/artifact/org.springframework/spring-context -->
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -181,14 +175,9 @@
 					<instructions>
 						<Atlassian-Plugin-Key>${atlassian.plugin.key}</Atlassian-Plugin-Key>
 						<!-- Add package to export here -->
-						<Export-Package>com.semmle.jira.addon.api,</Export-Package>
+						<Export-Package>com.semmle.jira.addon.config.upgrades</Export-Package>
 						<!-- Add package import here -->
-						<Import-Package>org.springframework.osgi.*;resolution:="optional",
-							org.eclipse.gemini.blueprint.*;resolution:="optional",
-							org.codehaus.jackson.*,
-							org.codehaus.jackson.annotate.*,
-							org.codehaus.jackson.map.*,
-							 *</Import-Package>
+						<Import-Package>*</Import-Package>
 						<!-- Ensure plugin is spring powered -->
 						<Spring-Context>*</Spring-Context>
 					</instructions>

--- a/src/main/java/com/semmle/jira/addon/config/AdminServlet.java
+++ b/src/main/java/com/semmle/jira/addon/config/AdminServlet.java
@@ -1,6 +1,5 @@
 package com.semmle.jira.addon.config;
 
-import com.atlassian.plugin.spring.scanner.annotation.component.Scanned;
 import com.atlassian.plugin.spring.scanner.annotation.imports.ComponentImport;
 import com.atlassian.sal.api.auth.LoginUriProvider;
 import com.atlassian.sal.api.user.UserManager;
@@ -13,8 +12,9 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
 
-@Scanned
+@Component
 public class AdminServlet extends HttpServlet {
   private static final long serialVersionUID = 1L;
   @ComponentImport private final UserManager userManager;

--- a/src/main/java/com/semmle/jira/addon/config/ConfigResource.java
+++ b/src/main/java/com/semmle/jira/addon/config/ConfigResource.java
@@ -4,7 +4,6 @@ import com.atlassian.jira.component.ComponentAccessor;
 import com.atlassian.jira.issue.issuetype.IssueType;
 import com.atlassian.jira.project.Project;
 import com.atlassian.jira.user.UserUtils;
-import com.atlassian.plugin.spring.scanner.annotation.component.Scanned;
 import com.atlassian.plugin.spring.scanner.annotation.imports.ComponentImport;
 import com.atlassian.sal.api.pluginsettings.PluginSettings;
 import com.atlassian.sal.api.pluginsettings.PluginSettingsFactory;
@@ -28,9 +27,10 @@ import javax.ws.rs.core.Response.Status;
 import org.ofbiz.core.entity.GenericEntityException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
 
+@Component
 @Path("/")
-@Scanned
 public class ConfigResource {
   private static final Logger log = LoggerFactory.getLogger(ConfigResource.class);
 

--- a/src/main/java/com/semmle/jira/addon/util/workflow/WorkflowUtils.java
+++ b/src/main/java/com/semmle/jira/addon/util/workflow/WorkflowUtils.java
@@ -1,14 +1,13 @@
 package com.semmle.jira.addon.util.workflow;
 
 import com.atlassian.jira.component.ComponentAccessor;
-import com.atlassian.jira.config.ConstantsManager;
 import com.atlassian.jira.config.ResolutionManager;
+import com.atlassian.jira.config.StatusCategoryManager;
 import com.atlassian.jira.config.StatusManager;
 import com.atlassian.jira.issue.priority.Priority;
 import com.atlassian.jira.issue.resolution.Resolution;
 import com.atlassian.jira.issue.status.Status;
 import com.atlassian.jira.issue.status.category.StatusCategory;
-import com.atlassian.jira.issue.status.category.StatusCategoryImpl;
 import com.atlassian.jira.ofbiz.OfBizDelegator;
 import com.atlassian.jira.user.ApplicationUser;
 import com.atlassian.jira.workflow.ConfigurableJiraWorkflow;
@@ -28,6 +27,7 @@ import com.opensymphony.workflow.loader.WorkflowDescriptor;
 import com.semmle.jira.addon.workflow.ResolutionCondition;
 import com.semmle.jira.addon.workflow.ResolutionValidator;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -244,18 +244,17 @@ public class WorkflowUtils {
 
   private static Status getOrCreateStatus(
       String statusName, String description, long statusCategoryId) {
-    Status status =
-        (Status)
-            ComponentAccessor.getConstantsManager()
-                .getIssueConstantByName(
-                    ConstantsManager.CONSTANT_TYPE.STATUS.getType(), statusName);
-    if (status != null) {
-      return status;
-    }
-
     StatusManager statusManager = ComponentAccessor.getComponent(StatusManager.class);
-    StatusCategory category = StatusCategoryImpl.findById(statusCategoryId);
-
+    Collection<Status> statuses = statusManager.getStatuses();
+    for (Status status : statuses) {
+      if (status.getName().equalsIgnoreCase(statusName)) {
+        return status;
+      }
+    }
+    StatusCategoryManager statusCategoryManager =
+        ComponentAccessor.getComponent(StatusCategoryManager.class);
+    StatusCategory category = statusCategoryManager.getStatusCategory(statusCategoryId);
+    if (category == null) category = statusCategoryManager.getDefaultStatusCategory();
     return statusManager.createStatus(statusName, description, "status.png", category);
   }
 

--- a/src/test/java/it/com/semmle/jira/addon/IntegrationTest.java
+++ b/src/test/java/it/com/semmle/jira/addon/IntegrationTest.java
@@ -5,11 +5,21 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
+import com.atlassian.jira.testkit.client.Backdoor;
+import com.atlassian.jira.testkit.client.restclient.Issue;
+import com.atlassian.jira.testkit.client.restclient.SearchRequest;
+import com.atlassian.jira.testkit.client.util.TestKitLocalEnvironmentData;
+import com.atlassian.jira.testkit.client.util.TimeBombLicence;
+import com.google.common.collect.Iterables;
+import com.semmle.jira.addon.Request;
+import com.semmle.jira.addon.Request.Transition;
+import com.semmle.jira.addon.Response;
+import com.semmle.jira.addon.Util;
+import com.semmle.jira.addon.config.Config;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Base64;
-
 import org.apache.http.HttpResponse;
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.HttpClient;
@@ -22,18 +32,6 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.junit.Before;
 import org.junit.Test;
-
-import com.atlassian.jira.testkit.client.Backdoor;
-import com.atlassian.jira.testkit.client.restclient.Issue;
-import com.atlassian.jira.testkit.client.restclient.SearchRequest;
-import com.atlassian.jira.testkit.client.util.TestKitLocalEnvironmentData;
-import com.atlassian.jira.testkit.client.util.TimeBombLicence;
-import com.google.common.collect.Iterables;
-import com.semmle.jira.addon.Request;
-import com.semmle.jira.addon.Request.Transition;
-import com.semmle.jira.addon.Response;
-import com.semmle.jira.addon.Util;
-import com.semmle.jira.addon.config.Config;
 
 public class IntegrationTest {
 


### PR DESCRIPTION
We had a problem with an exception during plugin install:
```
Upgrade error: Unexpected exception caught during plugin upgrade: com.atlassian.jira.exception.DataAccessException: A status with the name 'In Review' already exists.
    	at com.atlassian.jira.config.DefaultStatusManager.createStatus(DefaultStatusManager.java:69)
    	at com.semmle.jira.addon.util.workflow.WorkflowUtils.getOrCreateStatus(WorkflowUtils.java:259)
    	at com.semmle.jira.addon.util.workflow.WorkflowUtils.updateStatuses(WorkflowUtils.java:130)
```
I rewrote the exists-check in `getOrCreateStatus` method to match the one in the code that would throw the exception. I'm not sure why `ConstantsManager::getIssueConstantByName` did not always work.

In addition this PR cleans up some entries in the pom.xml file and removes `@Scanned` annotations which should no longer be required.