### PR TITLE
No longer rely on imported spring scanner annotation packages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
 					<instructions>
 						<Atlassian-Plugin-Key>${atlassian.plugin.key}</Atlassian-Plugin-Key>
 						<!-- Add package to export here -->
-						<Export-Package>com.semmle.jira.addon.config.upgrades</Export-Package>
+						<Export-Package></Export-Package>
 						<!-- Add package import here -->
 						<Import-Package>*</Import-Package>
 						<!-- Ensure plugin is spring powered -->

--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
 						<!-- Add package to export here -->
 						<Export-Package></Export-Package>
 						<!-- Add package import here -->
-						<Import-Package>*</Import-Package>
+						<Import-Package>com.atlassian.plugin.spring.scanner.annotation.export;version="0";resolution:=optional,com.atlassian.plugin.spring.scanner.annotation.imports;version="0";resolution:=optional,*</Import-Package>
 						<!-- Ensure plugin is spring powered -->
 						<Spring-Context>*</Spring-Context>
 					</instructions>


### PR DESCRIPTION
For some reason declaring the spring scanner annotation packages as imported results in dependency resolution errors for Jira 7.1 and below. We don't actually seem to need those packages at runtime, so it seems safe to declare them as "optional". 