### PR TITLE
Query to flag-up direct dependencies on jira-core

### DIFF
--- a/lgtm/java-queries/JiraCoreDependency.ql
+++ b/lgtm/java-queries/JiraCoreDependency.ql
@@ -1,0 +1,19 @@
+/**
+ * @name Direct dependency on jira core
+ * @description Plugins should not directly depend on classes defined in jira-core. 
+ *              Instead they should access them through components exposed by jira-api.
+ * @kind problem
+ * @problem.severity warning
+ * @precision very-high
+ * @id jira/jira-core-dependency
+ * @tags reliability
+         maintainability
+ */
+
+import java
+
+from Expr access, File file
+where file.getParentContainer+().getBaseName().matches("jira-core-%.jar")
+and (file = access.(TypeAccess).getType().getFile() or
+    file = access.(MethodAccess).getMethod().getFile())
+select access, "Dependency on jira-core"


### PR DESCRIPTION
We should avoid depending directly on the implementation details
of jira-core. Instead we should use the components exposed through
the API.

@Daverlo @nickfyson 