### PR TITLE
Add remote issue links to tickets

### DIFF
--- a/src/main/java/com/semmle/jira/addon/workflow/LgtmIssueLinkFunction.java
+++ b/src/main/java/com/semmle/jira/addon/workflow/LgtmIssueLinkFunction.java
@@ -1,0 +1,90 @@
+package com.semmle.jira.addon.workflow;
+
+import com.atlassian.jira.bc.issue.link.RemoteIssueLinkService;
+import com.atlassian.jira.bc.issue.link.RemoteIssueLinkService.CreateValidationResult;
+import com.atlassian.jira.bc.issue.link.RemoteIssueLinkService.RemoteIssueLinkResult;
+import com.atlassian.jira.component.ComponentAccessor;
+import com.atlassian.jira.issue.Issue;
+import com.atlassian.jira.issue.MutableIssue;
+import com.atlassian.jira.issue.link.RemoteIssueLink;
+import com.atlassian.jira.issue.link.RemoteIssueLinkBuilder;
+import com.atlassian.jira.user.ApplicationUser;
+import com.atlassian.jira.workflow.function.issue.AbstractJiraFunctionProvider;
+import com.opensymphony.module.propertyset.PropertySet;
+import com.opensymphony.workflow.WorkflowException;
+import com.semmle.jira.addon.Request;
+import com.semmle.jira.addon.Request.Transition;
+import com.semmle.jira.addon.util.Constants;
+import com.semmle.jira.addon.util.Util;
+import java.io.IOException;
+import java.util.Map;
+import org.codehaus.jackson.JsonNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LgtmIssueLinkFunction extends AbstractJiraFunctionProvider {
+
+  private static final Logger log = LoggerFactory.getLogger(LgtmIssueLinkFunction.class);
+
+  @Override
+  @SuppressWarnings("rawtypes")
+  public void execute(Map transientVars, Map args, PropertySet ps) throws WorkflowException {
+
+    if (!ComponentAccessor.getIssueLinkManager().isLinkingEnabled()) {
+      log.debug(
+          "LgtmIssueLinkFunction: Remote issue link creation skipped, because issue linking is disabled.");
+      return;
+    }
+
+    Object object = transientVars.get("issueProperties");
+    if (object instanceof Map) {
+      object = ((Map) object).get(Constants.LGTM_PAYLOAD_PROPERTY);
+      if (object instanceof JsonNode) {
+        JsonNode payload = (JsonNode) object;
+        Request request;
+        try {
+          request = Util.JSON.treeToValue(payload, Request.class);
+        } catch (IOException e) {
+          throw new WorkflowException("Could not read LGTM JSON payload", e);
+        }
+        if (request.transition != Transition.CREATE)
+          throw new WorkflowException(
+              LgtmIssueLinkFunction.class.getName() + " should only be used for issue creation.");
+
+        ApplicationUser user = getCallerUser(transientVars, args);
+        MutableIssue issue = getIssue(transientVars);
+        createRemoteLink(user, issue, request);
+      }
+    }
+  }
+
+  private void createRemoteLink(ApplicationUser user, Issue issue, Request request)
+      throws WorkflowException {
+    String url = request.alert.url;
+    String title = request.alert.query.name;
+
+    RemoteIssueLinkService issueLinkService =
+        ComponentAccessor.getComponent(RemoteIssueLinkService.class);
+    RemoteIssueLink link =
+        new RemoteIssueLinkBuilder()
+            .issueId(issue.getId())
+            .relationship("causes")
+            .url(url)
+            .title(title)
+            .applicationName("LGTM")
+            .applicationType("com.lgtm")
+            .build();
+    CreateValidationResult linkValidation = issueLinkService.validateCreate(user, link);
+    if (!linkValidation.isValid()) {
+      throw new WorkflowException(
+          "Could not create remote link due to: "
+              + linkValidation.getErrorCollection().getErrorMessages());
+    }
+    RemoteIssueLinkResult linkResult = issueLinkService.create(user, linkValidation);
+    if (!linkResult.isValid()) {
+      throw new WorkflowException(
+          "Could not create remote link due to: "
+              + linkResult.getErrorCollection().getErrorMessages());
+    }
+  }
+}

--- a/src/main/java/com/semmle/jira/addon/workflow/LgtmIssueLinkFunctionFactory.java
+++ b/src/main/java/com/semmle/jira/addon/workflow/LgtmIssueLinkFunctionFactory.java
@@ -1,0 +1,27 @@
+package com.semmle.jira.addon.workflow;
+
+import com.atlassian.jira.plugin.workflow.AbstractWorkflowPluginFactory;
+import com.atlassian.jira.plugin.workflow.WorkflowPluginFunctionFactory;
+import com.opensymphony.workflow.loader.AbstractDescriptor;
+import java.util.Collections;
+import java.util.Map;
+
+public class LgtmIssueLinkFunctionFactory extends AbstractWorkflowPluginFactory
+    implements WorkflowPluginFunctionFactory {
+
+  @Override
+  protected void getVelocityParamsForInput(Map<String, Object> velocityParams) {}
+
+  @Override
+  protected void getVelocityParamsForEdit(
+      Map<String, Object> velocityParams, AbstractDescriptor descriptor) {}
+
+  @Override
+  protected void getVelocityParamsForView(
+      Map<String, Object> velocityParams, AbstractDescriptor descriptor) {}
+
+  @Override
+  public Map<String, ?> getDescriptorParams(Map<String, Object> formParams) {
+    return Collections.emptyMap();
+  }
+}

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -48,6 +48,21 @@
 		<resource type="velocity" name="edit-parameters"
 			location="templates/postfunctions/lgtm-transition-notification-input.vm" />
 	</workflow-function>
+	<workflow-function key="lgtm-issue-link" name="LGTM Remote Issue Link"
+		i18n-name-key="lgtm-issue-link.name"
+		class="com.semmle.jira.addon.workflow.LgtmIssueLinkFunctionFactory">
+		<description key="lgtm-issue-link.description">Post-function that creates an LGTM remote
+			issue link.
+		</description>
+		<function-class>com.semmle.jira.addon.workflow.LgtmIssueLinkFunction</function-class>
+		<orderable>false</orderable>
+		<unique>true</unique>
+		<weight>100</weight>
+		<deletable>true</deletable>
+		<addable>initial</addable>
+		<resource type="velocity" name="view"
+			location="templates/postfunctions/lgtm-issue-link.vm" />
+	</workflow-function>
 	<workflow-validator key="resolution-validator" name="Resolution Validator"
 		i18n-name-key="resolution-validator.name" class="com.semmle.jira.addon.workflow.CheckResolutionFunctionFactory">
 		<description key="resolution-validator.description">Validates that the issue ticket has or

--- a/src/main/resources/lgtm-addon.properties
+++ b/src/main/resources/lgtm-addon.properties
@@ -25,3 +25,5 @@ resolution-condition.name=Resolution Condition
 resolution-validator.name=Resolution Validator
 resolution-validator.description=Validates that the issue ticket has or does not have a particular resolution.
 
+lgtm-issue-link.name=LGTM Remote Issue Link
+lgtm-issue-link.description=Post-function that creates an LGTM remote issue link.

--- a/src/main/resources/templates/postfunctions/lgtm-issue-link.vm
+++ b/src/main/resources/templates/postfunctions/lgtm-issue-link.vm
@@ -1,0 +1,1 @@
+Create a new LGTM issue link

--- a/src/main/resources/workflow/workflow.xml
+++ b/src/main/resources/workflow/workflow.xml
@@ -20,6 +20,10 @@
               <arg name="class.name">com.atlassian.jira.workflow.function.issue.IssueCreateFunction</arg>
             </function>
             <function type="class">
+              <arg name="full.module.key">com.semmle.lgtm-jira-addonlgtm-issue-link</arg>
+              <arg name="class.name">com.semmle.jira.addon.workflow.LgtmIssueLinkFunction</arg>
+            </function>
+            <function type="class">
               <arg name="class.name">com.atlassian.jira.workflow.function.issue.IssueReindexFunction</arg>
             </function>
             <function type="class">

--- a/src/test/java/com/semmle/jira/addon/TestCreateIssue.java
+++ b/src/test/java/com/semmle/jira/addon/TestCreateIssue.java
@@ -21,7 +21,6 @@ import com.atlassian.jira.issue.fields.layout.field.FieldLayout;
 import com.atlassian.jira.issue.fields.layout.field.FieldLayoutItem;
 import com.atlassian.jira.issue.fields.layout.field.FieldLayoutManager;
 import com.atlassian.jira.issue.issuetype.IssueType;
-import com.atlassian.jira.issue.label.LabelManager;
 import com.atlassian.jira.junit.rules.AvailableInContainer;
 import com.atlassian.jira.user.ApplicationUser;
 import com.atlassian.jira.util.ErrorCollection;
@@ -45,7 +44,6 @@ public class TestCreateIssue extends TestCreateAndTransitionBase {
   private static final String CONFIG_KEY = "config_key";
 
   @AvailableInContainer private ConstantsManager constantsManager = mock(ConstantsManager.class);
-  @AvailableInContainer private LabelManager labelManager = mock(LabelManager.class);
 
   @AvailableInContainer
   private ManagedConfigurationItemService managedConfigurationItemService =

--- a/src/test/java/com/semmle/jira/addon/workflow/LgtmIssueLinkFunctionTest.java
+++ b/src/test/java/com/semmle/jira/addon/workflow/LgtmIssueLinkFunctionTest.java
@@ -1,0 +1,89 @@
+package com.semmle.jira.addon.workflow;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.atlassian.jira.bc.issue.link.RemoteIssueLinkService;
+import com.atlassian.jira.bc.issue.link.RemoteIssueLinkService.CreateValidationResult;
+import com.atlassian.jira.bc.issue.link.RemoteIssueLinkService.RemoteIssueLinkResult;
+import com.atlassian.jira.issue.MutableIssue;
+import com.atlassian.jira.issue.link.IssueLinkManager;
+import com.atlassian.jira.issue.link.RemoteIssueLink;
+import com.atlassian.jira.junit.rules.AvailableInContainer;
+import com.atlassian.jira.junit.rules.MockitoContainer;
+import com.atlassian.jira.junit.rules.MockitoMocksInContainer;
+import com.opensymphony.workflow.WorkflowException;
+import com.semmle.jira.addon.Request;
+import com.semmle.jira.addon.Request.Alert;
+import com.semmle.jira.addon.Request.Alert.Query;
+import com.semmle.jira.addon.Request.Project;
+import com.semmle.jira.addon.Request.Transition;
+import com.semmle.jira.addon.util.Constants;
+import com.semmle.jira.addon.util.Util;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.codehaus.jackson.JsonNode;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class LgtmIssueLinkFunctionTest {
+  @Rule public MockitoContainer mockitoContainer = MockitoMocksInContainer.rule(this);
+
+  @AvailableInContainer private IssueLinkManager issueLinkManager = mock(IssueLinkManager.class);
+
+  @AvailableInContainer
+  private RemoteIssueLinkService issueLinkService = mock(RemoteIssueLinkService.class);
+
+  private LgtmIssueLinkFunction function;
+  private MutableIssue issue;
+
+  @Before
+  public void setup() {
+    when(issueLinkManager.isLinkingEnabled()).thenReturn(true);
+    issue = mock(MutableIssue.class);
+    when(issue.getId()).thenReturn(10L);
+    function = new LgtmIssueLinkFunction();
+  }
+
+  @Test
+  public void testExecute() throws WorkflowException {
+    CreateValidationResult validationResult = mock(CreateValidationResult.class);
+    when(issueLinkService.validateCreate(any(), any())).thenReturn(validationResult);
+    when(validationResult.isValid()).thenReturn(true);
+    RemoteIssueLinkResult linkResult = mock(RemoteIssueLinkResult.class);
+    when(issueLinkService.create(any(), any())).thenReturn(linkResult);
+    when(linkResult.isValid()).thenReturn(true);
+
+    Map<String, Object> transientVars = new LinkedHashMap<>();
+    Project project =
+        new Project(1L, "example/project", "Example project", "http://lgtm.example.com/projects/1");
+    Query query = new Query("Query name", "http://lgtm.example.com/rules/1");
+    Alert alert = new Alert("file", "some error", "http://lgtm.example.com/issues/...", query);
+    Request request = new Request(Transition.CREATE, null, project, alert);
+    JsonNode json = Util.JSON.valueToTree(request);
+    transientVars.put("issue", issue);
+    transientVars.put(
+        "issueProperties", Collections.singletonMap(Constants.LGTM_PAYLOAD_PROPERTY, json));
+    function.execute(transientVars, Collections.emptyMap(), null);
+
+    verify(issueLinkService)
+        .validateCreate(
+            any(),
+            argThat(
+                (RemoteIssueLink x) -> {
+                  Assert.assertEquals("LGTM", x.getApplicationName());
+                  Assert.assertEquals("com.lgtm", x.getApplicationType());
+                  Assert.assertEquals(alert.url, x.getUrl());
+                  Assert.assertEquals(issue.getId(), x.getIssueId());
+                  Assert.assertEquals("causes", x.getRelationship());
+                  Assert.assertEquals(alert.query.name, x.getTitle());
+                  return true;
+                }));
+  }
+}

--- a/src/test/java/it/com/semmle/jira/addon/IntegrationTest.java
+++ b/src/test/java/it/com/semmle/jira/addon/IntegrationTest.java
@@ -73,6 +73,7 @@ public class IntegrationTest {
     // Use TestKit to initialise a test instance of Jira
     testKit = new Backdoor(new TestKitLocalEnvironmentData());
     testKit.restoreBlankInstance(TimeBombLicence.LICENCE_FOR_TESTING);
+    testKit.issueLinking().enable();
 
     baseUrl = testKit.generalConfiguration().getEnvironmentData().getBaseUrl().toString();
     httpClient = HttpClientBuilder.create().build();


### PR DESCRIPTION
A post-function that create a renote issue link that links to the alert
on LGTM that caused the issue ticket.

See also:
https://developer.atlassian.com/server/jira/platform/creating-remote-issue-links/