### PR TITLE
Change manual migration message to indicate use of workflow schemes page

### DIFF
--- a/src/main/java/com/semmle/jira/addon/LgtmServlet.java
+++ b/src/main/java/com/semmle/jira/addon/LgtmServlet.java
@@ -160,7 +160,7 @@ public class LgtmServlet extends HttpServlet {
       sendError(
           resp,
           HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
-          "Retrieval of custom field for config key failed.");
+          "Retrieval of configuration key failed. Please check your add-on configuration.");
       return;
     }
 

--- a/src/main/java/com/semmle/jira/addon/util/JiraUtils.java
+++ b/src/main/java/com/semmle/jira/addon/util/JiraUtils.java
@@ -217,11 +217,14 @@ public class JiraUtils {
 
   public static CustomField getConfigKeyCustomField() throws CustomFieldRetrievalException {
 
+    Object settingsObject = getSettingsObject().get(Constants.CUSTOM_FIELD_CONFIG_KEY);
+
     long fieldId;
     try {
-      fieldId = Long.parseLong((String) getSettingsObject().get(Constants.CUSTOM_FIELD_CONFIG_KEY));
+      fieldId = Long.parseLong((String) settingsObject);
     } catch (ClassCastException | NumberFormatException e) {
-      throw new CustomFieldRetrievalException("Invalid custom field config key.", e);
+      throw new CustomFieldRetrievalException(
+          "Invalid custom field config key -> " + settingsObject.toString(), e);
     }
 
     CustomField customField =

--- a/src/main/java/com/semmle/jira/addon/util/JiraUtils.java
+++ b/src/main/java/com/semmle/jira/addon/util/JiraUtils.java
@@ -219,12 +219,24 @@ public class JiraUtils {
 
     Object settingsObject = getSettingsObject().get(Constants.CUSTOM_FIELD_CONFIG_KEY);
 
+    if (settingsObject == null) {
+      throw new CustomFieldRetrievalException(
+          "Null value found for plugin setting "
+              + Constants.CUSTOM_FIELD_CONFIG_KEY
+              + ". Indicates that the add-on has not yet been (re)configured.");
+    }
+
     long fieldId;
     try {
       fieldId = Long.parseLong((String) settingsObject);
     } catch (ClassCastException | NumberFormatException e) {
       throw new CustomFieldRetrievalException(
-          "Invalid custom field config key -> " + settingsObject.toString(), e);
+          "Invalid value for plugin setting "
+              + Constants.CUSTOM_FIELD_CONFIG_KEY
+              + " -> "
+              + settingsObject.toString()
+              + ". Should be long, corresponding to ID of LGTM custom field.",
+          e);
     }
 
     CustomField customField =
@@ -232,7 +244,9 @@ public class JiraUtils {
 
     if (customField == null) {
       throw new CustomFieldRetrievalException(
-          "Custom field not found with specified id = " + String.valueOf(fieldId));
+          "LGTM Custom Field not found for stored id ("
+              + String.valueOf(fieldId)
+              + "). Field has likely been unlocked and then deleted.");
     }
 
     return customField;

--- a/src/main/java/com/semmle/jira/addon/workflow/LgtmTransitionNotificationFunction.java
+++ b/src/main/java/com/semmle/jira/addon/workflow/LgtmTransitionNotificationFunction.java
@@ -42,7 +42,8 @@ public class LgtmTransitionNotificationFunction extends AbstractJiraFunctionProv
     try {
       customField = JiraUtils.getConfigKeyCustomField();
     } catch (CustomFieldRetrievalException e) {
-      String message = "Retrieval of custom field for config key failed.";
+      String message =
+          "Retrieval of configuration key failed. Please check your add-on configuration and try again.";
       log.error(message, e);
       throw new WorkflowException(message, e);
     }

--- a/src/main/resources/js/lgtm-addon.js
+++ b/src/main/resources/js/lgtm-addon.js
@@ -195,13 +195,12 @@ function updateConfig() {
 			
 			var body = '<p>There are existing tickets using an old workflow type, and hence a one-time manual migration is needed.</p>' +
 			'<ul>'+
-			'<li>Please go to the <a href="' + AJS.params.baseURL + '/plugins/servlet/project-config/'+
-				AJS.$('#project').select2('val') +
-				'/workflows" target="_blank">project workflow page</a> '+
-				"and select 'Add workflow' followed by 'Add existing'.</li>" +
+			'<li>Please go to the <a href="' + AJS.params.baseURL + '/secure/admin/ViewWorkflowSchemes.jspa" target="_blank">workflow schemes page</a> '+
+				"and click to edit the scheme associated with your project chosen above.</li>" +
+			"<li>Select 'Add workflow' followed by 'Add existing'.</li>" +
 			"<li>On the first screen select 'LGTM workflow' then on the second select 'LGTM alert'. Click 'Finish'.</li>" +
-			"<li>Finally, click 'Publish' and Jira will guide you through mapping tickets to the new workflow.</li>" +
-			'</ul>';
+			"<li>Finally, click 'Publish' and Jira will guide you through mapping tickets to the new workflow.</li>" 
+			"</ul>";
 			
 			AJS.messages.error("#message-context", {
 				title : 'A manual workflow migration is needed.',

--- a/src/main/resources/js/lgtm-addon.js
+++ b/src/main/resources/js/lgtm-addon.js
@@ -199,7 +199,7 @@ function updateConfig() {
 				"and click to edit the scheme associated with your project chosen above.</li>" +
 			"<li>Select 'Add workflow' followed by 'Add existing'.</li>" +
 			"<li>On the first screen select 'LGTM workflow' then on the second select 'LGTM alert'. Click 'Finish'.</li>" +
-			"<li>Finally, click 'Publish' and Jira will guide you through mapping tickets to the new workflow.</li>" 
+			"<li>Finally, click 'Publish' and Jira will guide you through mapping tickets to the new workflow.</li>" +
 			"</ul>";
 			
 			AJS.messages.error("#message-context", {


### PR DESCRIPTION
This approach will always work, regardless of whether the scheme in question is used my multiple projects. (I think including _both_ sets of instructions complicates things unnecessarily...)

Also adds a bit more information to an error message associated with retrieval of the custom field.

![image](https://user-images.githubusercontent.com/1482231/54985468-c46ba600-4fa8-11e9-9fec-ed0ce8318e47.png)