### PR TITLE
Fix typo in workflow xml that was causing corrupt post function

### DIFF
--- a/src/main/java/com/semmle/jira/addon/util/workflow/WorkflowUtils.java
+++ b/src/main/java/com/semmle/jira/addon/util/workflow/WorkflowUtils.java
@@ -106,7 +106,7 @@ public class WorkflowUtils {
     @SuppressWarnings("unchecked")
     List<ActionDescriptor> initialActions = workflow.getDescriptor().getInitialActions();
     for (ActionDescriptor action : initialActions) {
-      addFunction(action, setPriorityFunction);
+      addFunctionAsFirst(action, setPriorityFunction);
     }
   }
 
@@ -222,7 +222,7 @@ public class WorkflowUtils {
     }
   }
 
-  private static void addFunction(ActionDescriptor transition, FunctionDescriptor function) {
+  private static void addFunctionAsFirst(ActionDescriptor transition, FunctionDescriptor function) {
     @SuppressWarnings("unchecked")
     List<FunctionDescriptor> functions = transition.getUnconditionalResult().getPostFunctions();
     // remove existing functions with the same name
@@ -239,7 +239,7 @@ public class WorkflowUtils {
         }
       }
     }
-    functions.add(function);
+    functions.add(0, function);
   }
 
   private static Status getOrCreateStatus(

--- a/src/main/resources/workflow/workflow.xml
+++ b/src/main/resources/workflow/workflow.xml
@@ -24,8 +24,7 @@
             </function>
             <function type="class">
               <arg name="eventTypeId">1</arg>
-              <arg name="class.name">com.atlassian.jira.workflow.function.event.FireIssueEventFunction
-                            </arg>
+              <arg name="class.name">com.atlassian.jira.workflow.function.event.FireIssueEventFunction</arg>
             </function>
           </post-functions>
         </unconditional-result>


### PR DESCRIPTION
This change to the XML fixes the observed problem with the post-functions on the 'create' transition.

FYI @aibaars @Daverlo 