### PR TITLE
Fix NullPointerException and warnings

### DIFF
--- a/src/main/java/com/semmle/jira/addon/LgtmServlet.java
+++ b/src/main/java/com/semmle/jira/addon/LgtmServlet.java
@@ -154,7 +154,7 @@ public class LgtmServlet extends HttpServlet {
   }
 
   Long createIssue(Request request, Config config)
-      throws IOException, CustomFieldRetrievalException, CreateIssueException {
+      throws CustomFieldRetrievalException, CreateIssueException {
 
     IssueInputParameters issueInputParameters =
         ComponentAccessor.getIssueService().newIssueInputParameters();
@@ -195,7 +195,7 @@ public class LgtmServlet extends HttpServlet {
 
   void applyTransition(
       MutableIssue issue, String transitionName, boolean skipValidate, ApplicationUser user)
-      throws IOException, TransitionNotFoundException {
+      throws TransitionNotFoundException {
     IssueInputParameters issueInputParameters =
         ComponentAccessor.getIssueService().newIssueInputParameters();
     issueInputParameters.setRetainExistingValuesWhenParameterNotProvided(true, true);

--- a/src/main/java/com/semmle/jira/addon/config/Config.java
+++ b/src/main/java/com/semmle/jira/addon/config/Config.java
@@ -48,7 +48,14 @@ public class Config {
 
   @JsonProperty
   public void setKey(String key) {
-    this.properties.put(PROPERTY_NAME_KEY, key);
+    putProperty(PROPERTY_NAME_KEY, key);
+  }
+
+  private void putProperty(String key, String value) {
+    // Null values are not allowed in a Properties object,
+    // so we remove the entry instead.
+    if (value == null) properties.remove(key);
+    else properties.put(key, value);
   }
 
   @JsonProperty
@@ -58,7 +65,7 @@ public class Config {
 
   @JsonProperty
   public void setLgtmSecret(String lgtmSecret) {
-    this.properties.put(PROPERTY_NAME_LGTM_SECRET, lgtmSecret);
+    putProperty(PROPERTY_NAME_LGTM_SECRET, lgtmSecret);
   }
 
   @JsonProperty
@@ -68,7 +75,7 @@ public class Config {
 
   @JsonProperty
   public void setUsername(String username) {
-    this.properties.put(PROPERTY_NAME_USERNAME, username);
+    putProperty(PROPERTY_NAME_USERNAME, username);
   }
 
   @JsonProperty
@@ -78,7 +85,7 @@ public class Config {
 
   @JsonProperty
   public void setProjectKey(String projectKey) {
-    this.properties.put(PROPERTY_NAME_PROJECT_KEY, projectKey);
+    putProperty(PROPERTY_NAME_PROJECT_KEY, projectKey);
   }
 
   @JsonProperty
@@ -89,9 +96,8 @@ public class Config {
   }
 
   @JsonProperty
-  public void setExternalHookUrl(URI externalHookUrl) {
-    if (externalHookUrl == null) this.properties.put(PROPERTY_NAME_EXTERNAL_HOOK_URL, null);
-    else this.properties.put(PROPERTY_NAME_EXTERNAL_HOOK_URL, externalHookUrl.toString());
+  public void setExternalHookUrl(URI url) {
+    putProperty(PROPERTY_NAME_EXTERNAL_HOOK_URL, url == null ? null : url.toString());
   }
 
   @JsonProperty
@@ -101,7 +107,7 @@ public class Config {
 
   @JsonProperty
   public void setTrackerKey(String trackerKey) {
-    this.properties.put(PROPERTY_NAME_TRACKER_KEY, trackerKey);
+    putProperty(PROPERTY_NAME_TRACKER_KEY, trackerKey);
   }
 
   public Error validate() {

--- a/src/test/java/com/semmle/jira/addon/TestApplyTransition.java
+++ b/src/test/java/com/semmle/jira/addon/TestApplyTransition.java
@@ -20,10 +20,8 @@ import com.opensymphony.workflow.loader.ActionDescriptor;
 import com.semmle.jira.addon.LgtmServlet.TransitionNotFoundException;
 import com.semmle.jira.addon.config.Config;
 import com.semmle.jira.addon.util.Constants;
-import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
-import javax.servlet.http.HttpServletResponse;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -59,9 +57,7 @@ public class TestApplyTransition extends TestCreateAndTransitionBase {
   }
 
   @Test(expected = TransitionNotFoundException.class)
-  public void testApplyTransitionTransitionNotFound()
-      throws IOException, TransitionNotFoundException {
-    HttpServletResponse resp = mockResponse();
+  public void testApplyTransitionTransitionNotFound() throws TransitionNotFoundException {
 
     when(transitionValidationResult.isValid()).thenReturn(false);
 
@@ -72,8 +68,7 @@ public class TestApplyTransition extends TestCreateAndTransitionBase {
   }
 
   @Test
-  public void testApplyTransitionInvalid() throws IOException, TransitionNotFoundException {
-    HttpServletResponse resp = mockResponse();
+  public void testApplyTransitionInvalid() throws TransitionNotFoundException {
 
     when(transitionValidationResult.isValid()).thenReturn(true);
 
@@ -95,8 +90,7 @@ public class TestApplyTransition extends TestCreateAndTransitionBase {
   }
 
   @Test
-  public void testApplyTransitionSuccess() throws IOException, TransitionNotFoundException {
-    HttpServletResponse resp = mockResponse();
+  public void testApplyTransitionSuccess() throws TransitionNotFoundException {
 
     when(transitionValidationResult.isValid()).thenReturn(true);
 

--- a/src/test/java/com/semmle/jira/addon/TestCreateIssue.java
+++ b/src/test/java/com/semmle/jira/addon/TestCreateIssue.java
@@ -34,8 +34,6 @@ import com.semmle.jira.addon.Request.Transition;
 import com.semmle.jira.addon.config.Config;
 import com.semmle.jira.addon.util.Constants;
 import com.semmle.jira.addon.util.CustomFieldRetrievalException;
-import java.io.IOException;
-import javax.servlet.http.HttpServletResponse;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -129,9 +127,7 @@ public class TestCreateIssue extends TestCreateAndTransitionBase {
 
   @Test
   public void testCreateIssueSuccess()
-      throws IOException, IllegalArgumentException, CustomFieldRetrievalException,
-          CreateIssueException {
-    HttpServletResponse resp = mockResponse();
+      throws IllegalArgumentException, CustomFieldRetrievalException, CreateIssueException {
     Request request = createRequest("test", "Query", "test.cpp", "Security Error");
 
     when(createValidationResult.getErrorCollection().hasAnyErrors()).thenReturn(false);
@@ -145,9 +141,7 @@ public class TestCreateIssue extends TestCreateAndTransitionBase {
 
   @Test(expected = CreateIssueException.class)
   public void testCreateIssueFailure()
-      throws IOException, IllegalArgumentException, CustomFieldRetrievalException,
-          CreateIssueException {
-    HttpServletResponse resp = mockResponse();
+      throws IllegalArgumentException, CustomFieldRetrievalException, CreateIssueException {
     Request request = createRequest("test", "Query", "test.cpp", "Security Error");
 
     when(createValidationResult.getErrorCollection().hasAnyErrors()).thenReturn(true);

--- a/src/test/java/com/semmle/jira/addon/TestLgtmServletBase.java
+++ b/src/test/java/com/semmle/jira/addon/TestLgtmServletBase.java
@@ -1,16 +1,8 @@
 package com.semmle.jira.addon;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import com.atlassian.jira.junit.rules.MockitoContainer;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.List;
-import javax.servlet.ServletOutputStream;
-import javax.servlet.http.HttpServletResponse;
 import org.junit.Before;
 import org.junit.Rule;
 
@@ -32,32 +24,5 @@ public class TestLgtmServletBase {
             log.add(msg);
           }
         };
-  }
-
-  private static class MockServletOutputStream extends ServletOutputStream {
-    ByteArrayOutputStream out = new ByteArrayOutputStream();
-
-    @Override
-    public void write(int b) {
-      out.write(b);
-    }
-
-    @Override
-    public String toString() {
-      try {
-        return out.toString("UTF-8");
-      } catch (UnsupportedEncodingException e) {
-        throw new RuntimeException(e);
-      }
-    }
-  }
-
-  public HttpServletResponse mockResponse() throws IOException {
-    HttpServletResponse resp = mock(HttpServletResponse.class);
-    MockServletOutputStream out = new MockServletOutputStream();
-
-    when(resp.getOutputStream()).thenReturn(out);
-
-    return resp;
   }
 }


### PR DESCRIPTION
The refactoring introduced a null pointer exception. It turns out that the `Properties` class does not permit `null` values and throws a `NullPointerException` if a `null` value is put into it. Instead we should remove the entry.

In addition this PR fixes some warnings that were left-over after the refactoring.

@Daverlo 