### PR TITLE
Add repository containing webwork/pell-multipart-request dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -287,6 +287,12 @@
 			<url>https://repo.spring.io/libs-release/</url>
 			<layout>default</layout>
 		</repository>
+                <repository>
+                        <id>mulesoft-public</id>
+                        <name>Mulesoft Repository</name>
+                        <url>https://repository.mulesoft.org/nexus/content/repositories/public/</url>
+                        <layout>default</layout>
+                </repository>
 		<repository>
 			<id>atlassian-3rdparty</id>
 			<name>Atlassian 3rd-P Old Repository</name>
@@ -314,8 +320,20 @@
 			</snapshots>
 		</pluginRepository>
 		<pluginRepository>
+			<id>springio-plugins-release</id>
+			<name>Spring Plugins Repository</name>
+			<url>https://repo.spring.io/plugins-release/</url>
+			<layout>default</layout>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</pluginRepository>
+		<pluginRepository>
 			<id>atlassian-public</id>
-			<url>https://m2proxy.atlassian.com/repository/public/</url>
+			<url>https://packages.atlassian.com/repository/public/</url>
 			<releases>
 				<enabled>true</enabled>
 			</releases>

--- a/src/main/java/com/semmle/jira/addon/workflow/LgtmIssueLinkFunction.java
+++ b/src/main/java/com/semmle/jira/addon/workflow/LgtmIssueLinkFunction.java
@@ -8,6 +8,7 @@ import com.atlassian.jira.issue.Issue;
 import com.atlassian.jira.issue.MutableIssue;
 import com.atlassian.jira.issue.link.RemoteIssueLink;
 import com.atlassian.jira.issue.link.RemoteIssueLinkBuilder;
+import com.atlassian.jira.permission.ProjectPermissions;
 import com.atlassian.jira.user.ApplicationUser;
 import com.atlassian.jira.workflow.function.issue.AbstractJiraFunctionProvider;
 import com.opensymphony.module.propertyset.PropertySet;
@@ -53,7 +54,13 @@ public class LgtmIssueLinkFunction extends AbstractJiraFunctionProvider {
 
         ApplicationUser user = getCallerUser(transientVars, args);
         MutableIssue issue = getIssue(transientVars);
-        createRemoteLink(user, issue, request);
+        if (ComponentAccessor.getPermissionManager()
+            .hasPermission(ProjectPermissions.LINK_ISSUES, issue.getProjectObject(), user)) {
+          createRemoteLink(user, issue, request);
+        } else {
+          log.debug(
+              "LgtmIssueLinkFunction: Remote issue link creation skipped, because user has no LINK_ISSUES permission.");
+        }
       }
     }
   }

--- a/src/test/java/com/semmle/jira/addon/workflow/LgtmIssueLinkFunctionTest.java
+++ b/src/test/java/com/semmle/jira/addon/workflow/LgtmIssueLinkFunctionTest.java
@@ -15,6 +15,11 @@ import com.atlassian.jira.issue.link.RemoteIssueLink;
 import com.atlassian.jira.junit.rules.AvailableInContainer;
 import com.atlassian.jira.junit.rules.MockitoContainer;
 import com.atlassian.jira.junit.rules.MockitoMocksInContainer;
+import com.atlassian.jira.mock.workflow.MockWorkflowContext;
+import com.atlassian.jira.permission.ProjectPermissions;
+import com.atlassian.jira.security.PermissionManager;
+import com.atlassian.jira.user.ApplicationUser;
+import com.atlassian.jira.user.util.UserManager;
 import com.opensymphony.workflow.WorkflowException;
 import com.semmle.jira.addon.Request;
 import com.semmle.jira.addon.Request.Alert;
@@ -37,17 +42,31 @@ public class LgtmIssueLinkFunctionTest {
 
   @AvailableInContainer private IssueLinkManager issueLinkManager = mock(IssueLinkManager.class);
 
+  @AvailableInContainer private UserManager userManager = mock(UserManager.class);
+
+  @AvailableInContainer
+  private PermissionManager permissionsManager = mock(PermissionManager.class);
+
   @AvailableInContainer
   private RemoteIssueLinkService issueLinkService = mock(RemoteIssueLinkService.class);
 
   private LgtmIssueLinkFunction function;
   private MutableIssue issue;
 
+  private ApplicationUser user;
+
   @Before
   public void setup() {
     when(issueLinkManager.isLinkingEnabled()).thenReturn(true);
     issue = mock(MutableIssue.class);
     when(issue.getId()).thenReturn(10L);
+    user = mock(ApplicationUser.class);
+    when(user.getKey()).thenReturn("userkey");
+    when(userManager.getUserByKey(user.getKey())).thenReturn(user);
+    com.atlassian.jira.project.Project project = mock(com.atlassian.jira.project.Project.class);
+    when(issue.getProjectObject()).thenReturn(project);
+    when(permissionsManager.hasPermission(ProjectPermissions.LINK_ISSUES, project, user))
+        .thenReturn(true);
     function = new LgtmIssueLinkFunction();
   }
 
@@ -67,6 +86,8 @@ public class LgtmIssueLinkFunctionTest {
     Alert alert = new Alert("file", "some error", "http://lgtm.example.com/issues/...", query);
     Request request = new Request(Transition.CREATE, null, project, alert);
     JsonNode json = Util.JSON.valueToTree(request);
+
+    transientVars.put("context", new MockWorkflowContext(user.getKey()));
     transientVars.put("issue", issue);
     transientVars.put(
         "issueProperties", Collections.singletonMap(Constants.LGTM_PAYLOAD_PROPERTY, json));

--- a/src/test/java/it/com/semmle/jira/addon/IntegrationTest.java
+++ b/src/test/java/it/com/semmle/jira/addon/IntegrationTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
+import com.atlassian.jira.permission.ProjectPermissions;
 import com.atlassian.jira.testkit.client.Backdoor;
 import com.atlassian.jira.testkit.client.restclient.Issue;
 import com.atlassian.jira.testkit.client.restclient.SearchRequest;
@@ -78,8 +79,12 @@ public class IntegrationTest {
     testKit.usersAndGroups().addUser("developer", "password", "Developer", "developer@example.com");
     testKit.usersAndGroups().addUser("lgtm", "password", "LGTM", "lgtm@example.com");
     testKit.usersAndGroups().addUserToGroup("developer", "jira-developers");
-    testKit.project().addProject("Apollo", "AP", "developer");
 
+    long projectId = testKit.project().addProject("Apollo", "AP", "developer");
+    long schemeId = testKit.permissionSchemes().copyDefaultScheme("AP permissions");
+
+    testKit.permissionSchemes().addEveryonePermission(schemeId, ProjectPermissions.LINK_ISSUES);
+    testKit.project().setPermissionScheme(projectId, schemeId);
     baseUrl = testKit.generalConfiguration().getEnvironmentData().getBaseUrl().toString();
     httpClient = HttpClientBuilder.create().build();
 


### PR DESCRIPTION
Apparently webwork/pell-multipart-request used to be in the Atlassian 3rdparty repository, but it no longer is. The mulesoft repository still contains it, so adding it to the pom file.