### PR TITLE
Add post function that sets issue labels based on query metadata

### DIFF
--- a/src/main/java/com/semmle/jira/addon/LgtmServlet.java
+++ b/src/main/java/com/semmle/jira/addon/LgtmServlet.java
@@ -5,8 +5,6 @@ import com.atlassian.jira.component.ComponentAccessor;
 import com.atlassian.jira.issue.IssueInputParameters;
 import com.atlassian.jira.issue.MutableIssue;
 import com.atlassian.jira.issue.fields.CustomField;
-import com.atlassian.jira.issue.fields.LabelsField;
-import com.atlassian.jira.issue.label.LabelParser;
 import com.atlassian.jira.user.ApplicationUser;
 import com.atlassian.jira.util.ErrorCollection;
 import com.atlassian.jira.workflow.JiraWorkflow;
@@ -178,10 +176,6 @@ public class LgtmServlet extends HttpServlet {
     CustomField customField = JiraUtils.getConfigKeyCustomField();
 
     createValidationResult.getIssue().setCustomFieldValue(customField, config.getKey());
-
-    // replace label separators (spaces) with underscores
-    String projectLabel = request.project.name.replace(LabelsField.SEPARATOR_CHAR, "_");
-    createValidationResult.getIssue().setLabels(LabelParser.buildFromString(projectLabel));
 
     IssueService.IssueResult issueResult =
         ComponentAccessor.getIssueService().create(config.getUser(), createValidationResult);

--- a/src/main/java/com/semmle/jira/addon/Request.java
+++ b/src/main/java/com/semmle/jira/addon/Request.java
@@ -2,6 +2,7 @@ package com.semmle.jira.addon;
 
 import com.semmle.jira.addon.util.Util;
 import java.io.IOException;
+import java.util.List;
 import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.annotate.JsonCreator;
 import org.codehaus.jackson.annotate.JsonIgnoreProperties;
@@ -73,7 +74,7 @@ public class Request {
     // Rule name with link to rule help
     description
         .append("*[")
-        .append(Util.escape(this.alert.query.name))
+        .append(Util.escape(this.alert.query.getName()))
         .append("|")
         .append(Util.escape(this.alert.query.url))
         .append("]*\n\n");
@@ -92,7 +93,7 @@ public class Request {
   }
 
   String getSummary() {
-    return String.format("%s (%s)", this.alert.query.name, this.project.name);
+    return String.format("%s (%s)", this.alert.query.getName(), this.project.name);
   }
 
   public static enum Transition {
@@ -182,33 +183,51 @@ public class Request {
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Query {
-      @JsonProperty public final String name;
+      @Deprecated @JsonProperty private final String name;
+      @JsonProperty public final String language;
       @JsonProperty public final Properties properties;
       @JsonProperty public final String url;
 
       public static class Properties {
+        @JsonProperty public final String id;
+        @JsonProperty public final String name;
         @JsonProperty public final String severity;
+        @JsonProperty public final List<String> tags;
 
         @JsonCreator
-        public Properties(@JsonProperty("severity") String severity) {
+        public Properties(
+            @JsonProperty("id") String id,
+            @JsonProperty("name") String name,
+            @JsonProperty("severity") String severity,
+            @JsonProperty("tags") List<String> tags) {
+          this.id = id;
+          this.name = name;
           this.severity = severity;
+          this.tags = tags;
         }
       }
 
       @JsonCreator
       public Query(
           @JsonProperty("name") String name,
+          @JsonProperty("language") String language,
           @JsonProperty("properties") Properties properties,
           @JsonProperty("url") String url) {
+        this.language = language;
         this.name = name;
         this.properties = properties;
         this.url = url;
       }
 
       boolean isValid() {
-        if (name == null) return false;
+        if (getName() == null) return false;
         if (url == null) return false;
         return true;
+      }
+
+      public String getName() {
+        if (properties != null && properties.name != null) return properties.name;
+        return name;
       }
     }
   }

--- a/src/main/java/com/semmle/jira/addon/config/upgrades/UpgradeTask5AddSetLabelsFunction.java
+++ b/src/main/java/com/semmle/jira/addon/config/upgrades/UpgradeTask5AddSetLabelsFunction.java
@@ -1,0 +1,79 @@
+package com.semmle.jira.addon.config.upgrades;
+
+import com.atlassian.jira.component.ComponentAccessor;
+import com.atlassian.jira.workflow.JiraWorkflow;
+import com.atlassian.jira.workflow.WorkflowManager;
+import com.atlassian.plugin.spring.scanner.annotation.export.ExportAsService;
+import com.atlassian.sal.api.message.Message;
+import com.atlassian.sal.api.upgrade.PluginUpgradeTask;
+import com.opensymphony.workflow.loader.ActionDescriptor;
+import com.opensymphony.workflow.loader.DescriptorFactory;
+import com.opensymphony.workflow.loader.FunctionDescriptor;
+import com.semmle.jira.addon.util.Constants;
+import com.semmle.jira.addon.workflow.LgtmSetLabelsFunction;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+@ExportAsService(PluginUpgradeTask.class)
+@Component
+public class UpgradeTask5AddSetLabelsFunction implements PluginUpgradeTask {
+  private final int BUILD_NUMER = 5;
+
+  @Override
+  public Collection<Message> doUpgrade() {
+
+    FunctionDescriptor setLabelsFunction =
+        DescriptorFactory.getFactory().createFunctionDescriptor();
+    setLabelsFunction.setType("class");
+
+    Map<String, String> args = setLabelsFunction.getArgs();
+    args.put("full.module.key", "com.semmle.lgtm-jira-addonlgtm-set-labels");
+    args.put("class.name", LgtmSetLabelsFunction.class.getName());
+    args.put("project.label", "true");
+
+    WorkflowManager workflowManager = ComponentAccessor.getWorkflowManager();
+    JiraWorkflow workflow = workflowManager.getWorkflow(Constants.WORKFLOW_NAME);
+
+    List<ActionDescriptor> initialActions = workflow.getDescriptor().getInitialActions();
+    for (ActionDescriptor action : initialActions) {
+      List<FunctionDescriptor> functions = action.getUnconditionalResult().getPostFunctions();
+      boolean alreadyExists = false;
+      Iterator<?> iter = functions.iterator();
+      while (iter.hasNext()) {
+        Object obj = iter.next();
+        if (obj instanceof FunctionDescriptor) {
+          FunctionDescriptor fun = (FunctionDescriptor) obj;
+          if (LgtmSetLabelsFunction.class.getName().equals(fun.getArgs().get("class.name"))) {
+            alreadyExists = true;
+            break;
+          }
+        }
+      }
+      if (!alreadyExists) {
+        functions.add(0, setLabelsFunction);
+        workflowManager.saveWorkflowWithoutAudit(workflow);
+      }
+    }
+
+    return Collections.emptySet();
+  }
+
+  @Override
+  public int getBuildNumber() {
+    return BUILD_NUMER;
+  }
+
+  @Override
+  public String getShortDescription() {
+    return "Upgrade Task " + BUILD_NUMER + " add Set Labels post function to workflow";
+  }
+
+  @Override
+  public String getPluginKey() {
+    return Constants.PLUGIN_KEY;
+  }
+}

--- a/src/main/java/com/semmle/jira/addon/workflow/LgtmIssueLinkFunction.java
+++ b/src/main/java/com/semmle/jira/addon/workflow/LgtmIssueLinkFunction.java
@@ -68,7 +68,7 @@ public class LgtmIssueLinkFunction extends AbstractJiraFunctionProvider {
   private void createRemoteLink(ApplicationUser user, Issue issue, Request request)
       throws WorkflowException {
     String url = request.alert.url;
-    String title = request.alert.query.name;
+    String title = request.alert.query.getName();
 
     RemoteIssueLinkService issueLinkService =
         ComponentAccessor.getComponent(RemoteIssueLinkService.class);

--- a/src/main/java/com/semmle/jira/addon/workflow/LgtmSetLabelsFunction.java
+++ b/src/main/java/com/semmle/jira/addon/workflow/LgtmSetLabelsFunction.java
@@ -1,0 +1,112 @@
+package com.semmle.jira.addon.workflow;
+
+import com.atlassian.jira.issue.MutableIssue;
+import com.atlassian.jira.issue.fields.LabelsField;
+import com.atlassian.jira.issue.label.Label;
+import com.atlassian.jira.issue.label.LabelParser;
+import com.atlassian.jira.workflow.function.issue.AbstractJiraFunctionProvider;
+import com.opensymphony.module.propertyset.PropertySet;
+import com.opensymphony.workflow.WorkflowException;
+import com.semmle.jira.addon.Request;
+import com.semmle.jira.addon.Request.Transition;
+import com.semmle.jira.addon.util.Constants;
+import com.semmle.jira.addon.util.Util;
+import java.io.IOException;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import org.codehaus.jackson.JsonNode;
+
+public class LgtmSetLabelsFunction extends AbstractJiraFunctionProvider {
+
+  public static enum Field {
+    PROJECT_LABEL("Project"),
+    QUERY_ID_LABEL("Query identifier"),
+    QUERY_LANGUAGE_LABEL("Query language"),
+    QUERY_TAGS_LABEL("Query tags");
+
+    private final String displayName;
+
+    private Field(String displayName) {
+      this.displayName = displayName;
+    }
+
+    public String id() {
+      return name().toLowerCase(Locale.ENGLISH).replace('_', '.');
+    }
+
+    public String displayName() {
+      return displayName;
+    }
+  }
+
+  @Override
+  @SuppressWarnings("rawtypes")
+  public void execute(Map transientVars, Map args, PropertySet ps) throws WorkflowException {
+
+    Object object = transientVars.get("issueProperties");
+    if (object instanceof Map) {
+      object = ((Map) object).get(Constants.LGTM_PAYLOAD_PROPERTY);
+
+      if (object instanceof JsonNode) {
+        JsonNode payload = (JsonNode) object;
+
+        Request request;
+        try {
+          request = Util.JSON.treeToValue(payload, Request.class);
+        } catch (IOException e) {
+          throw new WorkflowException("Could not read LGTM JSON payload", e);
+        }
+        if (request.transition != Transition.CREATE)
+          throw new WorkflowException(
+              LgtmSetLabelsFunction.class.getName() + " should only be used for issue creation.");
+
+        Set<Label> labels = new LinkedHashSet<>();
+        MutableIssue issue = getIssue(transientVars);
+        if (issue.getLabels() != null) {
+          labels.addAll(issue.getLabels());
+        }
+
+        if (request.project != null) {
+          Label project = fromString(request.project.name);
+          if (project != null && isEnabled(Field.PROJECT_LABEL, args)) {
+            labels.add(project);
+          }
+        }
+
+        if (request.alert != null && request.alert.query != null) {
+          Label language = fromString(request.alert.query.language);
+          if (language != null && isEnabled(Field.QUERY_LANGUAGE_LABEL, args)) {
+            labels.add(language);
+          }
+
+          if (request.alert.query.properties != null) {
+            Label queryId = fromString(request.alert.query.properties.id);
+            if (queryId != null && isEnabled(Field.QUERY_ID_LABEL, args)) {
+              labels.add(queryId);
+            }
+
+            List<String> tags = request.alert.query.properties.tags;
+            if (tags != null && isEnabled(Field.QUERY_TAGS_LABEL, args)) {
+              tags.stream().map(LgtmSetLabelsFunction::fromString).forEach(labels::add);
+            }
+          }
+        }
+        issue.setLabels(labels);
+      }
+    }
+  }
+
+  private static boolean isEnabled(Field field, Map<String, ?> args) {
+    return Boolean.valueOf((String) args.get(field.id()));
+  }
+
+  private static Label fromString(String value) {
+    if (value == null || value.isEmpty()) return null;
+    Set<Label> label = LabelParser.buildFromString(value.replace(LabelsField.SEPARATOR_CHAR, "_"));
+    if (label.isEmpty()) return null;
+    return label.iterator().next();
+  }
+}

--- a/src/main/java/com/semmle/jira/addon/workflow/LgtmSetLabelsFunctionFactory.java
+++ b/src/main/java/com/semmle/jira/addon/workflow/LgtmSetLabelsFunctionFactory.java
@@ -1,0 +1,58 @@
+package com.semmle.jira.addon.workflow;
+
+import com.atlassian.jira.plugin.workflow.AbstractWorkflowPluginFactory;
+import com.atlassian.jira.plugin.workflow.WorkflowPluginFunctionFactory;
+import com.opensymphony.workflow.loader.AbstractDescriptor;
+import com.opensymphony.workflow.loader.FunctionDescriptor;
+import com.semmle.jira.addon.workflow.LgtmSetLabelsFunction.Field;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class LgtmSetLabelsFunctionFactory extends AbstractWorkflowPluginFactory
+    implements WorkflowPluginFunctionFactory {
+
+  @Override
+  protected void getVelocityParamsForInput(Map<String, Object> velocityParams) {
+    Map<Field, Boolean> fieldValues = new LinkedHashMap<>();
+    for (Field field : Field.values()) {
+      fieldValues.put(field, Boolean.FALSE);
+    }
+    velocityParams.put("fields", fieldValues);
+  }
+
+  @Override
+  protected void getVelocityParamsForEdit(
+      Map<String, Object> velocityParams, AbstractDescriptor descriptor) {
+    getVelocityParamsForInput(velocityParams);
+    getVelocityParamsForView(velocityParams, descriptor);
+  }
+
+  @Override
+  protected void getVelocityParamsForView(
+      Map<String, Object> velocityParams, AbstractDescriptor descriptor) {
+    if (!(descriptor instanceof FunctionDescriptor)) {
+      throw new IllegalArgumentException("Descriptor must be a FunctionDescriptor.");
+    }
+
+    FunctionDescriptor function = (FunctionDescriptor) descriptor;
+
+    Map<Field, Boolean> fieldValues = new LinkedHashMap<>();
+    for (Field field : Field.values()) {
+      String value = (String) function.getArgs().get(field.id());
+      fieldValues.put(field, Boolean.valueOf(value));
+    }
+    velocityParams.put("fields", fieldValues);
+  }
+
+  @Override
+  public Map<String, String> getDescriptorParams(Map<String, Object> formParams) {
+    Map<String, String> params = new LinkedHashMap<>();
+
+    for (Field field : Field.values()) {
+      String value = null;
+      if (formParams.containsKey(field.id())) value = extractSingleParam(formParams, field.id());
+      params.put(field.id(), Boolean.valueOf(value).toString());
+    }
+    return params;
+  }
+}

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -80,6 +80,25 @@
 		<resource type="velocity" name="edit-parameters"
 			location="templates/postfunctions/lgtm-severity-priority-input.vm" />
 	</workflow-function>
+	<workflow-function key="lgtm-set-labels"
+		name="LGTM Set Issue Labels" i18n-name-key="lgtm-set-labels.name"
+		class="com.semmle.jira.addon.workflow.LgtmSetLabelsFunctionFactory">
+		<description key="lgtm-set-labels.description">Post-function that sets labels based LGTM
+			alert alert metadata.</description>
+		<function-class>com.semmle.jira.addon.workflow.LgtmSetLabelsFunction
+		</function-class>
+		<orderable>true</orderable>
+		<unique>true</unique>
+		<weight>10</weight>
+		<deletable>true</deletable>
+		<addable>initial</addable>
+		<resource type="velocity" name="view"
+			location="templates/postfunctions/lgtm-set-labels.vm" />
+		<resource type="velocity" name="input-parameters"
+			location="templates/postfunctions/lgtm-set-labels-input.vm" />
+		<resource type="velocity" name="edit-parameters"
+			location="templates/postfunctions/lgtm-set-labels-input.vm" />
+	</workflow-function>
 	<workflow-validator key="resolution-validator" name="Resolution Validator"
 		i18n-name-key="resolution-validator.name" class="com.semmle.jira.addon.workflow.CheckResolutionFunctionFactory">
 		<description key="resolution-validator.description">Validates that the issue ticket has or

--- a/src/main/resources/lgtm-addon.properties
+++ b/src/main/resources/lgtm-addon.properties
@@ -30,3 +30,6 @@ lgtm-issue-link.description=Post-function that creates an LGTM remote issue link
 
 lgtm-severity-priority.name=LGTM Set Issue Priority
 lgtm-severity-priority.description=Post-function that sets priority based LGTM alert severity.
+
+lgtm-set-labels.name=LGTM Set Issue Labels
+lgtm-set-labels.description=Post-function that sets labels based LGTM alert alert metadata.

--- a/src/main/resources/templates/postfunctions/lgtm-set-labels-input.vm
+++ b/src/main/resources/templates/postfunctions/lgtm-set-labels-input.vm
@@ -1,0 +1,10 @@
+<div>
+<table>
+#foreach ($field in $fields.entrySet())
+<tr>
+  <th align="left"><label for="$field.getKey().id()">$field.getKey().displayName(): </label></th>
+  <td align="center"><input type="checkbox" name="$field.getKey().id()" id="$field.getKey().id()" value="true"#if ($field.getValue()) checked#end></td>
+</tr>
+#end
+</table>
+</div>

--- a/src/main/resources/templates/postfunctions/lgtm-set-labels.vm
+++ b/src/main/resources/templates/postfunctions/lgtm-set-labels.vm
@@ -1,0 +1,1 @@
+Set issue labels based on LGTM alert metadata

--- a/src/main/resources/workflow/workflow.xml
+++ b/src/main/resources/workflow/workflow.xml
@@ -21,6 +21,11 @@
               <arg name="class.name">com.semmle.jira.addon.workflow.LgtmSeverityPriorityFunction</arg>
             </function>
             <function type="class">
+              <arg name="full.module.key">com.semmle.lgtm-jira-addonlgtm-set-labels</arg>
+              <arg name="class.name">com.semmle.jira.addon.workflow.LgtmSetLabelsFunction</arg>
+              <arg name="project.label">true</arg>
+            </function>
+            <function type="class">
               <arg name="class.name">com.atlassian.jira.workflow.function.issue.IssueCreateFunction</arg>
             </function>
             <function type="class">

--- a/src/test/java/com/semmle/jira/addon/TestCreateIssue.java
+++ b/src/test/java/com/semmle/jira/addon/TestCreateIssue.java
@@ -71,7 +71,7 @@ public class TestCreateIssue extends TestCreateAndTransitionBase {
     Transition transition = Transition.CREATE;
     String url = "www." + projectName + ".com";
     Project project = new Project(1l, "g/" + projectName, projectName, url);
-    Query query = new Query(queryName, null, url + "/" + queryName);
+    Query query = new Query(queryName, null, null, url + "/" + queryName);
     Alert alert = new Alert(alertFile, alertMessage, url + "/alert", query);
 
     return new Request(transition, null, project, alert);

--- a/src/test/java/com/semmle/jira/addon/workflow/LgtmIssueLinkFunctionTest.java
+++ b/src/test/java/com/semmle/jira/addon/workflow/LgtmIssueLinkFunctionTest.java
@@ -82,7 +82,7 @@ public class LgtmIssueLinkFunctionTest {
     Map<String, Object> transientVars = new LinkedHashMap<>();
     Project project =
         new Project(1L, "example/project", "Example project", "http://lgtm.example.com/projects/1");
-    Query query = new Query("Query name", null, "http://lgtm.example.com/rules/1");
+    Query query = new Query("Query name", null, null, "http://lgtm.example.com/rules/1");
     Alert alert = new Alert("file", "some error", "http://lgtm.example.com/issues/...", query);
     Request request = new Request(Transition.CREATE, null, project, alert);
     JsonNode json = Util.JSON.valueToTree(request);
@@ -103,7 +103,7 @@ public class LgtmIssueLinkFunctionTest {
                   Assert.assertEquals(alert.url, x.getUrl());
                   Assert.assertEquals(issue.getId(), x.getIssueId());
                   Assert.assertEquals("causes", x.getRelationship());
-                  Assert.assertEquals(alert.query.name, x.getTitle());
+                  Assert.assertEquals(alert.query.getName(), x.getTitle());
                   return true;
                 }));
   }

--- a/src/test/java/com/semmle/jira/addon/workflow/LgtmSetLabelsFunctionTest.java
+++ b/src/test/java/com/semmle/jira/addon/workflow/LgtmSetLabelsFunctionTest.java
@@ -1,0 +1,121 @@
+package com.semmle.jira.addon.workflow;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.atlassian.jira.issue.MutableIssue;
+import com.atlassian.jira.issue.label.LabelParser;
+import com.atlassian.jira.junit.rules.MockitoContainer;
+import com.atlassian.jira.junit.rules.MockitoMocksInContainer;
+import com.opensymphony.workflow.WorkflowException;
+import com.semmle.jira.addon.Request;
+import com.semmle.jira.addon.Request.Alert;
+import com.semmle.jira.addon.Request.Alert.Query;
+import com.semmle.jira.addon.Request.Alert.Query.Properties;
+import com.semmle.jira.addon.Request.Project;
+import com.semmle.jira.addon.Request.Transition;
+import com.semmle.jira.addon.util.Constants;
+import com.semmle.jira.addon.util.Util;
+import com.semmle.jira.addon.workflow.LgtmSetLabelsFunction.Field;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import org.codehaus.jackson.JsonNode;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class LgtmSetLabelsFunctionTest {
+  @Rule public MockitoContainer mockitoContainer = MockitoMocksInContainer.rule(this);
+
+  private LgtmSetLabelsFunction function;
+
+  @Before
+  public void setup() {
+    function = new LgtmSetLabelsFunction();
+  }
+
+  @Test
+  public void testExecute() throws WorkflowException {
+    // set project label
+    testExecute("Example project", null, null, EnumSet.of(Field.PROJECT_LABEL), "Example_project");
+    // unset project label
+    testExecute("Example project", null, null, Collections.emptySet(), "");
+    testExecute(
+        "Example project",
+        "javascript",
+        null,
+        EnumSet.of(Field.QUERY_LANGUAGE_LABEL),
+        "javascript");
+    testExecute(
+        "Example project",
+        null,
+        new Properties("query/id", null, null, null),
+        EnumSet.of(Field.QUERY_ID_LABEL),
+        "query/id");
+    testExecute(
+        "Example project",
+        null,
+        new Properties(null, null, null, Arrays.asList("security", "external/cwe")),
+        EnumSet.of(Field.QUERY_TAGS_LABEL),
+        "security external/cwe");
+    testExecute(
+        "Example project",
+        null,
+        new Properties(null, null, null, Collections.emptyList()),
+        EnumSet.of(Field.QUERY_TAGS_LABEL),
+        "");
+    // All fields turned on, but the JSON request has only null values
+    testExecute(null, null, null, EnumSet.allOf(Field.class), "");
+    // All fields turned on, JSON contains values for all
+    testExecute(
+        "Example project",
+        "java",
+        new Properties(
+            "query/id", "Query name", "warning", Arrays.asList("security", "external/cwe")),
+        EnumSet.allOf(Field.class),
+        "Example_project java query/id security external/cwe");
+    // All fields turned off, JSON contains values for all
+    testExecute(
+        "Example project",
+        "java",
+        new Properties(
+            "query/id", "Query name", "warning", Arrays.asList("security", "external/cwe")),
+        Collections.emptySet(),
+        "");
+  }
+
+  public void testExecute(
+      String projectName,
+      String language,
+      Properties properties,
+      Set<Field> settings,
+      String expected)
+      throws WorkflowException {
+    Map<String, Object> transientVars = new LinkedHashMap<>();
+    Project project =
+        new Project(1L, "example/project", projectName, "http://lgtm.example.com/projects/1");
+    Query query = new Query("Query name", language, properties, "http://lgtm.example.com/rules/1");
+    Alert alert = new Alert("file", "some error", "http://lgtm.example.com/issues/...", query);
+    Request request = new Request(Transition.CREATE, null, project, alert);
+    JsonNode json = Util.JSON.valueToTree(request);
+
+    MutableIssue issue = mock(MutableIssue.class);
+    when(issue.getId()).thenReturn(10L);
+
+    transientVars.put("issue", issue);
+    transientVars.put(
+        "issueProperties", Collections.singletonMap(Constants.LGTM_PAYLOAD_PROPERTY, json));
+    Map<String, String> args = new LinkedHashMap<>();
+    for (Field field : Field.values()) {
+      args.put(field.id(), Boolean.valueOf(settings.contains(field)).toString());
+    }
+    function.execute(transientVars, args, null);
+
+    Mockito.verify(issue).setLabels(LabelParser.buildFromString(expected));
+  }
+}

--- a/src/test/java/com/semmle/jira/addon/workflow/LgtmSeverityPriorityFunctionTest.java
+++ b/src/test/java/com/semmle/jira/addon/workflow/LgtmSeverityPriorityFunctionTest.java
@@ -51,8 +51,8 @@ public class LgtmSeverityPriorityFunctionTest {
     Map<String, Object> transientVars = new LinkedHashMap<>();
     Project project =
         new Project(1L, "example/project", "Example project", "http://lgtm.example.com/projects/1");
-    Properties properties = severity == null ? null : new Properties(severity);
-    Query query = new Query("Query name", properties, "http://lgtm.example.com/rules/1");
+    Properties properties = severity == null ? null : new Properties(null, null, severity, null);
+    Query query = new Query("Query name", null, properties, "http://lgtm.example.com/rules/1");
     Alert alert = new Alert("file", "some error", "http://lgtm.example.com/issues/...", query);
     Request request = new Request(Transition.CREATE, null, project, alert);
     JsonNode json = Util.JSON.valueToTree(request);


### PR DESCRIPTION
This pull request adds a post-function that populates issue ticket labels based on LGTM alert properties.
The following properties can be included as labels:
* project name
* query identifier
* query language
* query tags

Previously adding the project name as an issue ticket label was hard-coded. This is no longer the case. To maintain backwards compatibility the SetLabels post function is inserted into the existing workflow using a migration with the "set project name as label" toggle set to `true`.
