### PR TITLE
Prepend LGTM Transition notification with "advanced"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.semmle</groupId>
 	<artifactId>lgtm-jira-addon</artifactId>
-	<version>0.2.1</version>
+	<version>0.2.2-SNAPSHOT</version>
 	<organization>
 		<name>Semmle</name>
 		<url>https://semmle.com</url>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.semmle</groupId>
 	<artifactId>lgtm-jira-addon</artifactId>
-	<version>0.2.1-SNAPSHOT</version>
+	<version>0.2.1</version>
 	<organization>
 		<name>Semmle</name>
 		<url>https://semmle.com</url>

--- a/src/main/java/com/semmle/jira/addon/config/upgrades/UpgradeTask6UpdateConfig.java
+++ b/src/main/java/com/semmle/jira/addon/config/upgrades/UpgradeTask6UpdateConfig.java
@@ -1,0 +1,71 @@
+package com.semmle.jira.addon.config.upgrades;
+
+import com.atlassian.jira.component.ComponentAccessor;
+import com.atlassian.plugin.spring.scanner.annotation.export.ExportAsService;
+import com.atlassian.sal.api.message.Message;
+import com.atlassian.sal.api.pluginsettings.PluginSettings;
+import com.atlassian.sal.api.pluginsettings.PluginSettingsFactory;
+import com.atlassian.sal.api.upgrade.PluginUpgradeTask;
+import com.semmle.jira.addon.config.Config;
+import com.semmle.jira.addon.util.Constants;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Properties;
+import org.springframework.stereotype.Component;
+
+@ExportAsService(PluginUpgradeTask.class)
+@Component
+public class UpgradeTask6UpdateConfig implements PluginUpgradeTask {
+  private final int BUILD_NUMER = 6;
+
+  @Override
+  public Collection<Message> doUpgrade() {
+
+    PluginSettingsFactory pluginSettingsFactory =
+        ComponentAccessor.getOSGiComponentInstanceOfType(PluginSettingsFactory.class);
+    PluginSettings settings = pluginSettingsFactory.createGlobalSettings();
+
+    String configKey = (String) settings.get("com.lgtm.addon.config.key");
+    // If there are no configuration settings yet, skip the upgrade
+    if (configKey == null) {
+      return Collections.emptySet();
+    }
+
+    // If there already is a correct configuration object, skip the upgrade
+    if (settings.get("com.lgtm.addon.config." + configKey) != null) {
+      return Collections.emptySet();
+    }
+
+    // Create a new configuration object if any of the old properties exist
+    String lgtmSecret = (String) settings.get("com.lgtm.addon.config." + configKey + ".lgtmSecret");
+    String username = (String) settings.get("com.lgtm.addon.config." + configKey + ".username");
+    String projectKey = (String) settings.get("com.lgtm.addon.config." + configKey + ".projectKey");
+    String externalHookUrl =
+        (String) settings.get("com.lgtm.addon.config." + configKey + ".externalHookUrl");
+    if (lgtmSecret != null || username != null || projectKey != null || externalHookUrl != null) {
+      Properties properties = new Properties();
+      properties.setProperty("key", configKey);
+      properties.setProperty("lgtmSecret", lgtmSecret);
+      properties.setProperty("username", username);
+      properties.setProperty("projectKey", projectKey);
+      properties.setProperty("externalHookUrl", externalHookUrl);
+      Config.put(new Config(properties));
+    }
+    return Collections.emptySet();
+  }
+
+  @Override
+  public int getBuildNumber() {
+    return BUILD_NUMER;
+  }
+
+  @Override
+  public String getShortDescription() {
+    return "Upgrade Task " + BUILD_NUMER + " update configuration";
+  }
+
+  @Override
+  public String getPluginKey() {
+    return Constants.PLUGIN_KEY;
+  }
+}

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -35,7 +35,7 @@
 		<resource type="download" name="images/" location="/images" />
 		<context>lgtm-addon</context>
 	</web-resource>
-	<workflow-function key="lgtm-transition-notification" name="LGTM Transition Notification"
+	<workflow-function key="lgtm-transition-notification" name="Advanced: LGTM Transition Notification"
 		i18n-name-key="lgtm-transition-notification.name" class="com.semmle.jira.addon.workflow.LgtmTransitionNotificationFunctionFactory">
 		<description key="lgtm-transition-notification.description">Post-function that sends transition notifications to LGTM.
 		</description>

--- a/src/main/resources/lgtm-addon.properties
+++ b/src/main/resources/lgtm-addon.properties
@@ -18,7 +18,7 @@ lgtm-servlet.admin.save.label=Save
 rest.name=LGTM configuration REST API
 lgtm-addon-resources.name=LGTM add-on web resources
 
-lgtm-transition-notification.name=LGTM Transition Notification
+lgtm-transition-notification.name=Advanced: LGTM Transition Notification
 lgtm-transition-notification.description=Sends a transition notification to LGTM.
 
 resolution-condition.name=Resolution Condition


### PR DESCRIPTION
Prepend LGTM Transition notification with "advanced". This should make it more clear that users should normally not configure that post function themselves.

In addition bump the version number.

@Daverlo 